### PR TITLE
Refactor to MVC and add singleton DB connection

### DIFF
--- a/gerenciador_postgres/connection_manager.py
+++ b/gerenciador_postgres/connection_manager.py
@@ -1,0 +1,31 @@
+import psycopg2
+from psycopg2.extensions import connection
+
+
+class ConnectionManager:
+    """Singleton para gerenciar a conexão com o banco de dados."""
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._conn = None
+        return cls._instance
+
+    def connect(self, **params) -> connection:
+        """Estabelece uma nova conexão usando os parâmetros fornecidos."""
+        if self._conn:
+            self.disconnect()
+        self._conn = psycopg2.connect(**params)
+        return self._conn
+
+    def get_connection(self) -> connection:
+        """Retorna a conexão ativa, se houver."""
+        return self._conn
+
+    def disconnect(self):
+        """Encerra a conexão ativa, se existir."""
+        if self._conn:
+            self._conn.close()
+            self._conn = None
+

--- a/gerenciador_postgres/controllers/__init__.py
+++ b/gerenciador_postgres/controllers/__init__.py
@@ -1,0 +1,4 @@
+from .users_controller import UsersController
+
+__all__ = ["UsersController"]
+

--- a/gerenciador_postgres/controllers/users_controller.py
+++ b/gerenciador_postgres/controllers/users_controller.py
@@ -1,0 +1,42 @@
+from PyQt6.QtCore import QObject, pyqtSignal
+
+
+class UsersController(QObject):
+    """Controller que orquestra operações de usuário e grupo."""
+
+    data_changed = pyqtSignal()
+
+    def __init__(self, role_manager):
+        super().__init__()
+        self.role_manager = role_manager
+
+    def list_entities(self):
+        users = self.role_manager.list_users()
+        groups = self.role_manager.list_groups()
+        return users, groups
+
+    def create_user(self, username: str, password: str):
+        result = self.role_manager.create_user(username, password)
+        self.data_changed.emit()
+        return result
+
+    def create_group(self, group_name: str):
+        result = self.role_manager.create_group(group_name)
+        self.data_changed.emit()
+        return result
+
+    def delete_user(self, username: str) -> bool:
+        success = self.role_manager.delete_user(username)
+        if success:
+            self.data_changed.emit()
+        return success
+
+    def delete_group(self, group_name: str) -> bool:
+        success = self.role_manager.delete_group(group_name)
+        if success:
+            self.data_changed.emit()
+        return success
+
+    def change_password(self, username: str, new_password: str) -> bool:
+        return self.role_manager.change_password(username, new_password)
+


### PR DESCRIPTION
## Summary
- centralize database connection handling with `ConnectionManager` singleton
- add `UsersController` and integrate views for a clearer MVC structure
- refresh user/group views via Qt signals implementing an observer pattern

## Testing
- `python -m py_compile gerenciador_postgres/connection_manager.py gerenciador_postgres/controllers/__init__.py gerenciador_postgres/controllers/users_controller.py gerenciador_postgres/gui/main_window.py gerenciador_postgres/gui/users_view.py`


------
https://chatgpt.com/codex/tasks/task_e_6893b5d7ea50832ea977ff55b009aa1a