### PR TITLE
feat: centralize application name

### DIFF
--- a/gerenciador_postgres/gui/main_window.py
+++ b/gerenciador_postgres/gui/main_window.py
@@ -1,5 +1,5 @@
 from PyQt6.QtWidgets import QMainWindow, QLabel, QMenuBar
-from PyQt6.QtWidgets import QStatusBar, QApplication, QMessageBox, QDialog 
+from PyQt6.QtWidgets import QStatusBar, QApplication, QMessageBox, QDialog
 from PyQt6.QtGui import QAction
 from PyQt6.QtCore import Qt
 from .connection_dialog import ConnectionDialog
@@ -7,12 +7,13 @@ import psycopg2
 from ..db_manager import DBManager
 from ..role_manager import RoleManager
 from ..logger import setup_logger
+from ..settings import APP_NAME
 
 
 class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("Gerenciador PostgreSQL")
+        self.setWindowTitle(APP_NAME)
         self.resize(900, 600)
         self._setup_menu()
         self._setup_statusbar()
@@ -85,11 +86,13 @@ class MainWindow(QMainWindow):
             # Adiciona à lista para que ela não seja descartada pela memória
             self.opened_windows.append(users_window)
             # Define um título para a nova janela
-            users_window.setWindowTitle("Gerenciador de Usuários e Grupos")
+            users_window.setWindowTitle(
+                f"Gerenciador de Usuários e Grupos - {APP_NAME}"
+            )
             # Mostra a nova janela
             users_window.show()
         else:
-            QMessageBox.warning(self, "Não Conectado", "Você precisa estar conectado a um banco de dados para gerenciar usuários.")
+            QMessageBox.warning(self, APP_NAME, "Você precisa estar conectado a um banco de dados para gerenciar usuários.")
 
 
     def on_conectar(self):
@@ -102,14 +105,14 @@ class MainWindow(QMainWindow):
                 self.role_manager = RoleManager(self.db_manager, self.logger, operador=params['user'])
                 self.menuGerenciar.setEnabled(True)
                 self.statusbar.showMessage(f"Conectado a {params['database']} como {params['user']}")
-                QMessageBox.information(self, "Conexão bem-sucedida", f"Conectado ao banco {params['database']}.")
+                QMessageBox.information(self, APP_NAME, f"Conectado ao banco {params['database']}.")
             except Exception as e:
                 self.db_conn = None
                 self.db_manager = None
                 self.role_manager = None
                 self.menuGerenciar.setEnabled(False)
                 self.statusbar.showMessage("Não conectado")
-                QMessageBox.critical(self, "Erro de conexão", f"Falha ao conectar: {e}")
+                QMessageBox.critical(self, APP_NAME, f"Falha ao conectar: {e}")
 
     def on_desconectar(self):
         if self.db_conn:
@@ -122,9 +125,9 @@ class MainWindow(QMainWindow):
         self.role_manager = None
         self.menuGerenciar.setEnabled(False)
         self.statusbar.showMessage("Não conectado")
-        QMessageBox.information(self, "Desconectado", "Conexão encerrada.")
+        QMessageBox.information(self, APP_NAME, "Conexão encerrada.")
 
     def _setup_central(self):
-        self.label = QLabel("Bem-vindo ao Gerenciador PostgreSQL!\nUtilize o menu para começar.", self)
+        self.label = QLabel(f"Bem-vindo ao {APP_NAME}!\nUtilize o menu para começar.", self)
         self.label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.setCentralWidget(self.label)

--- a/gerenciador_postgres/gui/users_view.py
+++ b/gerenciador_postgres/gui/users_view.py
@@ -2,12 +2,13 @@ from PyQt6.QtWidgets import (QWidget, QSplitter, QLineEdit, QListWidget, QTabWid
                              QVBoxLayout, QToolBar, QPushButton, QLabel, QListWidgetItem,
                              QInputDialog, QMessageBox)
 from PyQt6.QtCore import Qt
+from ..settings import APP_NAME
 
 class UsersView(QWidget):
     def __init__(self, parent=None, role_manager=None):
         super().__init__(parent)
         self.role_manager = role_manager
-        self.setWindowTitle("Gerenciador de Usuários e Grupos")
+        self.setWindowTitle(f"Gerenciador de Usuários e Grupos - {APP_NAME}")
         self._setup_ui()
         self._connect_signals()
         self.refresh_lists()
@@ -64,7 +65,7 @@ class UsersView(QWidget):
                 item.setData(Qt.ItemDataRole.UserRole, ('user', user))
                 self.lstEntities.addItem(item)
         except Exception as e:
-            QMessageBox.critical(self, "Erro de Listagem", f"Não foi possível listar usuários: {e}")
+            QMessageBox.critical(self, APP_NAME, f"Não foi possível listar usuários: {e}")
         try:
             groups = self.role_manager.list_groups()
             for group in groups:
@@ -72,7 +73,7 @@ class UsersView(QWidget):
                 item.setData(Qt.ItemDataRole.UserRole, ('group', group))
                 self.lstEntities.addItem(item)
         except Exception as e:
-            QMessageBox.critical(self, "Erro de Listagem", f"Não foi possível listar grupos: {e}")
+            QMessageBox.critical(self, APP_NAME, f"Não foi possível listar grupos: {e}")
 
     def filter_list(self):
         filter_text = self.txtFilter.text().lower()
@@ -98,34 +99,40 @@ class UsersView(QWidget):
         self.btnDelete.setEnabled(True)
 
     def on_new_user_clicked(self):
-        username, ok1 = QInputDialog.getText(self, "Novo Usuário", "Digite o nome do novo usuário:")
+        username, ok1 = QInputDialog.getText(
+            self, f"Novo Usuário - {APP_NAME}", "Digite o nome do novo usuário:"
+        )
         if ok1 and username:
             username = username.lower()
         else: return
-        password, ok2 = QInputDialog.getText(self, "Nova Senha", f"Senha para '{username}':", QLineEdit.EchoMode.Password)
+        password, ok2 = QInputDialog.getText(
+            self, f"Nova Senha - {APP_NAME}", f"Senha para '{username}':", QLineEdit.EchoMode.Password
+        )
         if not ok2 or not password: return
         try:
             self.role_manager.create_user(username, password)
-            QMessageBox.information(self, "Sucesso", f"Usuário '{username}' criado com sucesso!")
+            QMessageBox.information(self, APP_NAME, f"Usuário '{username}' criado com sucesso!")
             self.refresh_lists()
         except Exception as e:
-            QMessageBox.critical(self, "Erro", f"Não foi possível criar o usuário.\nMotivo: {e}")
+            QMessageBox.critical(self, APP_NAME, f"Não foi possível criar o usuário.\nMotivo: {e}")
 
     def on_new_group_clicked(self):
-        group_name, ok = QInputDialog.getText(self, "Novo Grupo", "Digite o nome do novo grupo (deve começar com 'grp_'):")
+        group_name, ok = QInputDialog.getText(
+            self, f"Novo Grupo - {APP_NAME}", "Digite o nome do novo grupo (deve começar com 'grp_'):"
+        )
         if not ok or not group_name: return
         try:
             self.role_manager.create_group(group_name)
-            QMessageBox.information(self, "Sucesso", f"Grupo '{group_name}' criado com sucesso!")
+            QMessageBox.information(self, APP_NAME, f"Grupo '{group_name}' criado com sucesso!")
             self.refresh_lists()
         except Exception as e:
-            QMessageBox.critical(self, "Erro", f"Não foi possível criar o grupo.\nMotivo: {e}")
+            QMessageBox.critical(self, APP_NAME, f"Não foi possível criar o grupo.\nMotivo: {e}")
 
     def on_delete_item_clicked(self):
         current_item = self.lstEntities.currentItem()
         if not current_item: return
         entity_type, entity_name = current_item.data(Qt.ItemDataRole.UserRole)
-        reply = QMessageBox.question(self, "Confirmar Deleção", f"Tem certeza que deseja deletar o {entity_type} '{entity_name}'?", QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No)
+        reply = QMessageBox.question(self, APP_NAME, f"Tem certeza que deseja deletar o {entity_type} '{entity_name}'?", QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No)
         if reply == QMessageBox.StandardButton.Yes:
             try:
                 success = False
@@ -133,24 +140,26 @@ class UsersView(QWidget):
                     success = self.role_manager.delete_user(entity_name)
                 elif entity_type == 'group':
                     success = self.role_manager.delete_group(entity_name)
-                
+
                 if success:
-                    QMessageBox.information(self, "Sucesso", f"{entity_type.capitalize()} '{entity_name}' deletado com sucesso.")
+                    QMessageBox.information(self, APP_NAME, f"{entity_type.capitalize()} '{entity_name}' deletado com sucesso.")
                     self.refresh_lists()
                 else:
-                    QMessageBox.critical(self, "Erro", f"Ocorreu um erro ao deletar o item. Verifique os logs.")
+                    QMessageBox.critical(self, APP_NAME, f"Ocorreu um erro ao deletar o item. Verifique os logs.")
             except Exception as e:
-                QMessageBox.critical(self, "Erro", f"Não foi possível deletar o item.\nMotivo: {e}")
+                QMessageBox.critical(self, APP_NAME, f"Não foi possível deletar o item.\nMotivo: {e}")
 
     def on_change_password_clicked(self):
         current_item = self.lstEntities.currentItem()
         if not current_item: return
         entity_type, username = current_item.data(Qt.ItemDataRole.UserRole)
         if entity_type != 'user': return
-        password, ok = QInputDialog.getText(self, "Alterar Senha", f"Nova senha para '{username}':", QLineEdit.EchoMode.Password)
+        password, ok = QInputDialog.getText(
+            self, f"Alterar Senha - {APP_NAME}", f"Nova senha para '{username}':", QLineEdit.EchoMode.Password
+        )
         if ok and password:
             try:
                 self.role_manager.change_password(username, password)
-                QMessageBox.information(self, "Sucesso", "Senha alterada com sucesso!")
+                QMessageBox.information(self, APP_NAME, "Senha alterada com sucesso!")
             except Exception as e:
-                 QMessageBox.critical(self, "Erro", f"Não foi possível alterar a senha.\nMotivo: {e}")
+                 QMessageBox.critical(self, APP_NAME, f"Não foi possível alterar a senha.\nMotivo: {e}")

--- a/gerenciador_postgres/settings.py
+++ b/gerenciador_postgres/settings.py
@@ -1,0 +1,1 @@
+APP_NAME = "Gerenciador PostgreSQL"


### PR DESCRIPTION
## Summary
- introduce settings module defining `APP_NAME`
- reference `APP_NAME` in dialog and window titles
- unify QMessageBox titles across GUI modules
- append program name to window-specific titles following `"Title - APP_NAME"` pattern

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893b643a69c832e8bd301e14f60ae9d