### PR TITLE
Add help dialog to GUI

### DIFF
--- a/gerenciador_postgres/gui/help_dialog.py
+++ b/gerenciador_postgres/gui/help_dialog.py
@@ -1,0 +1,12 @@
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QTextBrowser
+
+
+class HelpDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Ajuda")
+        layout = QVBoxLayout(self)
+        self.browser = QTextBrowser(self)
+        self.browser.setHtml("<p>Ajuda inicial</p>")
+        layout.addWidget(self.browser)
+

--- a/gerenciador_postgres/gui/main_window.py
+++ b/gerenciador_postgres/gui/main_window.py
@@ -47,6 +47,7 @@ class MainWindow(QMainWindow):
         self.actionAuditoria = QAction("Auditoria", self)
 
         # Ações do menu Ajuda
+        self.actionAjuda = QAction("Ajuda", self)
         self.actionSobre = QAction("Sobre", self)
 
         # --- Conectar Sinais (Handlers) ---
@@ -54,6 +55,7 @@ class MainWindow(QMainWindow):
         self.actionDesconectar.triggered.connect(self.on_desconectar)
         self.actionSair.triggered.connect(self.close)
         self.actionUsuariosGrupos.triggered.connect(self.on_usuarios_grupos)
+        self.actionAjuda.triggered.connect(self.show_help)
         # Outras ações seriam conectadas aqui no futuro...
 
         # --- Adicionar Ações aos Menus ---
@@ -71,6 +73,7 @@ class MainWindow(QMainWindow):
         self.menuGerenciar.setEnabled(False) # Começa desabilitado
 
         # Menu Ajuda
+        self.menuAjuda.addAction(self.actionAjuda)
         self.menuAjuda.addAction(self.actionSobre)
 
     def _setup_statusbar(self):
@@ -122,6 +125,11 @@ class MainWindow(QMainWindow):
         self.menuGerenciar.setEnabled(False)
         self.statusbar.showMessage("Não conectado")
         QMessageBox.information(self, "Desconectado", "Conexão encerrada.")
+
+    def show_help(self):
+        from .help_dialog import HelpDialog
+        dlg = HelpDialog(self)
+        dlg.exec()
 
     def _setup_central(self):
         self.label = QLabel("Bem-vindo ao Gerenciador PostgreSQL!\nUtilize o menu para começar.", self)


### PR DESCRIPTION
## Summary
- add HelpDialog with QTextBrowser containing basic HTML help text
- integrate Ajuda action in main window and wire it to show the help dialog

## Testing
- `python -m py_compile gerenciador_postgres/gui/help_dialog.py gerenciador_postgres/gui/main_window.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893caf3a028832e9393139c91983f5f