### PR TITLE
Add splash screen to application startup

### DIFF
--- a/Rodar.py
+++ b/Rodar.py
@@ -1,12 +1,25 @@
 from gerenciador_postgres.gui.main_window import MainWindow
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtWidgets import QApplication, QSplashScreen
+from PyQt6.QtGui import QPixmap
+from PyQt6.QtCore import QTimer
 import sys
+
 
 def main():
     app = QApplication(sys.argv)
+
+    pixmap = QPixmap()
+    splash = QSplashScreen(pixmap)
+    splash.show()
+    app.processEvents()
+
     window = MainWindow()
     window.show()
+
+    QTimer.singleShot(1000, lambda: splash.finish(window))
+
     sys.exit(app.exec())
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- display a QSplashScreen before launching the main window
- close the splash screen with a QTimer after the window is shown

## Testing
- `python -m py_compile Rodar.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893caf542d8832e8816157b68aef454