### PR TITLE
Add schema management with permissions and GUI

### DIFF
--- a/gerenciador_postgres/controllers/__init__.py
+++ b/gerenciador_postgres/controllers/__init__.py
@@ -1,4 +1,5 @@
 from .users_controller import UsersController
+from .schema_controller import SchemaController
 
-__all__ = ["UsersController"]
+__all__ = ["UsersController", "SchemaController"]
 

--- a/gerenciador_postgres/controllers/schema_controller.py
+++ b/gerenciador_postgres/controllers/schema_controller.py
@@ -1,0 +1,42 @@
+from PyQt6.QtCore import QObject, pyqtSignal
+
+
+class SchemaController(QObject):
+    """Controller que orquestra as operações de schema."""
+
+    data_changed = pyqtSignal()
+
+    def __init__(self, schema_manager, logger):
+        super().__init__()
+        self.schema_manager = schema_manager
+        self.logger = logger
+
+    def list_schemas(self):
+        return self.schema_manager.list_schemas()
+
+    def create_schema(self, name: str, owner: str | None = None):
+        try:
+            result = self.schema_manager.create_schema(name, owner)
+            self.data_changed.emit()
+            return result
+        except Exception as e:
+            self.logger.error(f"Erro ao criar schema '{name}': {e}")
+            raise
+
+    def delete_schema(self, name: str, cascade: bool = False):
+        try:
+            result = self.schema_manager.delete_schema(name, cascade)
+            self.data_changed.emit()
+            return result
+        except Exception as e:
+            self.logger.error(f"Erro ao remover schema '{name}': {e}")
+            raise
+
+    def change_owner(self, name: str, new_owner: str):
+        try:
+            result = self.schema_manager.change_owner(name, new_owner)
+            self.data_changed.emit()
+            return result
+        except Exception as e:
+            self.logger.error(f"Erro ao alterar proprietário do schema '{name}': {e}")
+            raise

--- a/gerenciador_postgres/db_manager.py
+++ b/gerenciador_postgres/db_manager.py
@@ -129,3 +129,10 @@ class DBManager:
             """)
             return [row[0] for row in cur.fetchall()]
 
+    def enable_postgis(self, schema_name: str):
+        """Garante que a extensão PostGIS esteja disponível no schema informado."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f'CREATE EXTENSION IF NOT EXISTS postgis SCHEMA "{schema_name}"'
+            )
+

--- a/gerenciador_postgres/gui/schema_view.py
+++ b/gerenciador_postgres/gui/schema_view.py
@@ -1,8 +1,113 @@
-from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel
+from PyQt6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QToolBar,
+    QPushButton,
+    QListWidget,
+    QInputDialog,
+    QMessageBox,
+)
+
 
 class SchemaView(QWidget):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, controller=None, logger=None):
         super().__init__(parent)
+        self.controller = controller
+        self.logger = logger
+        self.setWindowTitle("Gerenciador de Schemas")
+        self._setup_ui()
+        self._connect_signals()
+        if self.controller:
+            self.controller.data_changed.connect(self.refresh_list)
+        self.refresh_list()
+
+    def _setup_ui(self):
         layout = QVBoxLayout(self)
-        layout.addWidget(QLabel("Gerenciamento de Schemas (em desenvolvimento)"))
+        self.toolbar = QToolBar()
+        self.btnNew = QPushButton("Novo Schema")
+        self.btnDelete = QPushButton("Excluir")
+        self.btnOwner = QPushButton("Alterar Owner")
+        self.btnDelete.setEnabled(False)
+        self.btnOwner.setEnabled(False)
+        self.toolbar.addWidget(self.btnNew)
+        self.toolbar.addWidget(self.btnDelete)
+        self.toolbar.addWidget(self.btnOwner)
+        layout.addWidget(self.toolbar)
+        self.lstSchemas = QListWidget()
+        layout.addWidget(self.lstSchemas)
         self.setLayout(layout)
+
+    def _connect_signals(self):
+        self.btnNew.clicked.connect(self.on_new_schema)
+        self.btnDelete.clicked.connect(self.on_delete_schema)
+        self.btnOwner.clicked.connect(self.on_change_owner)
+        self.lstSchemas.currentItemChanged.connect(self.on_schema_selected)
+
+    def refresh_list(self):
+        self.lstSchemas.clear()
+        if not self.controller:
+            return
+        try:
+            for schema in self.controller.list_schemas():
+                self.lstSchemas.addItem(schema)
+        except Exception as e:
+            QMessageBox.critical(self, "Erro", f"Falha ao listar schemas:\n{e}")
+            if self.logger:
+                self.logger.error(f"Falha ao listar schemas: {e}")
+
+    def on_schema_selected(self, current, previous):
+        has_item = current is not None
+        self.btnDelete.setEnabled(has_item)
+        self.btnOwner.setEnabled(has_item)
+
+    def on_new_schema(self):
+        name, ok = QInputDialog.getText(self, "Novo Schema", "Nome do schema:")
+        if not ok or not name:
+            return
+        owner, ok2 = QInputDialog.getText(self, "Proprietário", "Owner (opcional):")
+        if not ok2:
+            owner = None
+        try:
+            self.controller.create_schema(name, owner or None)
+            QMessageBox.information(self, "Sucesso", f"Schema '{name}' criado.")
+        except Exception as e:
+            QMessageBox.critical(self, "Erro", f"Não foi possível criar o schema:\n{e}")
+            if self.logger:
+                self.logger.error(f"Falha ao criar schema '{name}': {e}")
+
+    def on_delete_schema(self):
+        item = self.lstSchemas.currentItem()
+        if not item:
+            return
+        name = item.text()
+        reply = QMessageBox.question(
+            self,
+            "Confirmar",
+            f"Excluir schema '{name}'?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            try:
+                self.controller.delete_schema(name)
+                QMessageBox.information(self, "Sucesso", f"Schema '{name}' removido.")
+            except Exception as e:
+                QMessageBox.critical(self, "Erro", f"Não foi possível remover o schema:\n{e}")
+                if self.logger:
+                    self.logger.error(f"Falha ao remover schema '{name}': {e}")
+
+    def on_change_owner(self):
+        item = self.lstSchemas.currentItem()
+        if not item:
+            return
+        name = item.text()
+        new_owner, ok = QInputDialog.getText(self, "Alterar Owner", f"Novo owner para '{name}':")
+        if not ok or not new_owner:
+            return
+        try:
+            self.controller.change_owner(name, new_owner)
+            QMessageBox.information(self, "Sucesso", f"Owner de '{name}' alterado.")
+        except Exception as e:
+            QMessageBox.critical(self, "Erro", f"Não foi possível alterar owner:\n{e}")
+            if self.logger:
+                self.logger.error(f"Falha ao alterar owner de '{name}': {e}")

--- a/gerenciador_postgres/schema_manager.py
+++ b/gerenciador_postgres/schema_manager.py
@@ -10,9 +10,54 @@ class SchemaManager:
         self.logger = logger
         self.operador = operador
 
+    # --- Helpers de permissão -------------------------------------------------
+    def _current_user(self) -> str:
+        with self.dao.conn.cursor() as cur:
+            cur.execute('SELECT current_user')
+            return cur.fetchone()[0]
+
+    def _has_role(self, username: str, role: str) -> bool:
+        with self.dao.conn.cursor() as cur:
+            cur.execute("SELECT pg_has_role(%s, %s, 'member')", (username, role))
+            row = cur.fetchone()
+            return bool(row and row[0])
+
+    def _is_superuser(self, username: str) -> bool:
+        with self.dao.conn.cursor() as cur:
+            cur.execute("SELECT usesuper FROM pg_user WHERE usename = %s", (username,))
+            row = cur.fetchone()
+            return bool(row and row[0])
+
+    def _get_schema_owner(self, schema: str) -> str | None:
+        with self.dao.conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT pg_catalog.pg_get_userbyid(nspowner)
+                FROM pg_namespace
+                WHERE nspname = %s
+                """,
+                (schema,),
+            )
+            row = cur.fetchone()
+            return row[0] if row else None
+
+    # --- Operações ------------------------------------------------------------
     def create_schema(self, name: str, owner: str | None = None):
+        user = self._current_user()
+        if not (self._is_superuser(user) or self._has_role(user, 'Professores')):
+            self.logger.error(
+                f"[{self.operador}] Usuário '{user}' não tem permissão para criar schema"
+            )
+            raise PermissionError('Apenas Professores ou superusuários podem criar schemas.')
         try:
             self.dao.create_schema(name, owner)
+            if hasattr(self.dao, 'enable_postgis'):
+                try:
+                    self.dao.enable_postgis(name)
+                except Exception as e:
+                    self.logger.warning(
+                        f"[{self.operador}] Falha ao habilitar PostGIS no schema '{name}': {e}"
+                    )
             self.dao.conn.commit()
             self.logger.info(f"[{self.operador}] Criou schema: {name}")
         except Exception as e:
@@ -21,6 +66,13 @@ class SchemaManager:
             raise
 
     def delete_schema(self, name: str, cascade: bool = False):
+        user = self._current_user()
+        owner = self._get_schema_owner(name)
+        if not (self._is_superuser(user) or user == owner):
+            self.logger.error(
+                f"[{self.operador}] Usuário '{user}' não pode remover schema '{name}'"
+            )
+            raise PermissionError('Apenas o proprietário ou um superusuário pode remover schemas.')
         try:
             self.dao.drop_schema(name, cascade)
             self.dao.conn.commit()

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -1,0 +1,119 @@
+import logging
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from gerenciador_postgres.schema_manager import SchemaManager
+
+
+class DummyConn:
+    def __init__(self):
+        self.committed = False
+        self.rolled_back = False
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+
+    # Context manager cursor for tests; not used because methods are overridden
+    def cursor(self):
+        class DummyCursor:
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, exc_type, exc, tb):
+                pass
+
+            def execute(self_inner, *args, **kwargs):
+                pass
+
+            def fetchone(self_inner):
+                return (None,)
+
+        return DummyCursor()
+
+
+class DummyDAO:
+    def __init__(self):
+        self.conn = DummyConn()
+        self.created = []
+        self.dropped = []
+
+    def create_schema(self, name, owner=None):
+        self.created.append((name, owner))
+
+    def drop_schema(self, name, cascade=False):
+        self.dropped.append((name, cascade))
+
+    def alter_schema_owner(self, name, owner):
+        pass
+
+    def list_schemas(self):
+        return []
+
+
+class TestableSchemaManager(SchemaManager):
+    def __init__(self, dao, logger, perms):
+        super().__init__(dao, logger)
+        self._user = perms.get('user', 'alice')
+        self._is_super = perms.get('super', False)
+        self._in_prof = perms.get('professor', False)
+        self._owner = perms.get('owner', None)
+
+    def _current_user(self):
+        return self._user
+
+    def _has_role(self, username, role):
+        return self._in_prof if role == 'Professores' else False
+
+    def _is_superuser(self, username):
+        return self._is_super
+
+    def _get_schema_owner(self, schema):
+        return self._owner
+
+
+class SchemaManagerPermissionTests(unittest.TestCase):
+    def setUp(self):
+        logger = logging.getLogger('test')
+        logger.addHandler(logging.NullHandler())
+        self.dao = DummyDAO()
+        self.logger = logger
+
+    def test_create_schema_authorized(self):
+        mgr = TestableSchemaManager(self.dao, self.logger, {'professor': True})
+        mgr.create_schema('novo')
+        self.assertEqual(self.dao.created, [('novo', None)])
+        self.assertTrue(self.dao.conn.committed)
+
+    def test_create_schema_unauthorized(self):
+        mgr = TestableSchemaManager(self.dao, self.logger, {'professor': False})
+        with self.assertRaises(PermissionError):
+            mgr.create_schema('novo')
+        self.assertEqual(self.dao.created, [])
+        self.assertFalse(self.dao.conn.committed)
+        self.assertFalse(self.dao.conn.rolled_back)  # Permission check occurs before transaction
+
+    def test_delete_schema_authorized_owner(self):
+        perms = {'owner': 'alice'}
+        mgr = TestableSchemaManager(self.dao, self.logger, perms)
+        mgr.delete_schema('teste')
+        self.assertEqual(self.dao.dropped, [('teste', False)])
+        self.assertTrue(self.dao.conn.committed)
+
+    def test_delete_schema_unauthorized(self):
+        perms = {'owner': 'other'}
+        mgr = TestableSchemaManager(self.dao, self.logger, perms)
+        with self.assertRaises(PermissionError):
+            mgr.delete_schema('teste')
+        self.assertEqual(self.dao.dropped, [])
+        self.assertFalse(self.dao.conn.committed)
+        self.assertFalse(self.dao.conn.rolled_back)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- enforce Professores/superuser rule for schema creation and owner/superuser rule for deletion
- add SchemaController and SchemaView for managing schemas with logging
- hook schema management into main window and enable PostGIS support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893ceb26724832e89156cc15e412da3