### PR TITLE
Generate splash image at runtime instead of committing binary file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Ignore generated splash image
+assets/splash.png

--- a/Rodar.py
+++ b/Rodar.py
@@ -2,13 +2,20 @@ from gerenciador_postgres.gui.main_window import MainWindow
 from PyQt6.QtWidgets import QApplication, QSplashScreen
 from PyQt6.QtGui import QPixmap
 from PyQt6.QtCore import QTimer
+from pathlib import Path
+import subprocess
 import sys
 
 
 def main():
     app = QApplication(sys.argv)
 
-    pixmap = QPixmap()
+    assets_dir = Path(__file__).resolve().parent / "assets"
+    splash_path = assets_dir / "splash.png"
+    if not splash_path.exists():
+        subprocess.run([sys.executable, str(assets_dir / "create_splash.py")], check=True)
+
+    pixmap = QPixmap(str(splash_path))
     splash = QSplashScreen(pixmap)
     splash.show()
     app.processEvents()

--- a/assets/create_splash.py
+++ b/assets/create_splash.py
@@ -1,0 +1,20 @@
+import base64
+from pathlib import Path
+
+PNG_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII="
+)
+
+def generate_splash(path: Path) -> None:
+    data = base64.b64decode(PNG_BASE64)
+    path.write_bytes(data)
+
+
+def main() -> None:
+    assets_dir = Path(__file__).resolve().parent
+    splash_path = assets_dir / "splash.png"
+    generate_splash(splash_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ignore generated splash image in version control
- create assets/create_splash.py to build a minimal splash image
- generate splash at runtime in Rodar.py if missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893d37d043c832e924531434bc324c9