### PR TITLE
Ensure ConnectionManager only returns active connections

### DIFF
--- a/gerenciador_postgres/connection_manager.py
+++ b/gerenciador_postgres/connection_manager.py
@@ -20,8 +20,10 @@ class ConnectionManager:
         return self._conn
 
     def get_connection(self) -> connection:
-        """Retorna a conexão ativa, se houver."""
-        return self._conn
+        """Retorna a conexão ativa, garantindo que esteja aberta."""
+        if self._conn and getattr(self._conn, "closed", 1) == 0:
+            return self._conn
+        raise ConnectionError("Conexão não ativa")
 
     def disconnect(self):
         """Encerra a conexão ativa, se existir."""

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from unittest.mock import MagicMock
+import pytest
+
+# Ensure project root is on path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from gerenciador_postgres.connection_manager import ConnectionManager
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    ConnectionManager._instance = None
+    yield
+    ConnectionManager._instance = None
+
+
+def test_get_connection_active():
+    cm = ConnectionManager()
+    mock_conn = MagicMock()
+    mock_conn.closed = 0
+    cm._conn = mock_conn
+    assert cm.get_connection() is mock_conn
+
+
+def test_get_connection_inactive():
+    cm = ConnectionManager()
+    mock_conn = MagicMock()
+    mock_conn.closed = 1
+    cm._conn = mock_conn
+    with pytest.raises(ConnectionError):
+        cm.get_connection()


### PR DESCRIPTION
## Summary
- Guard `ConnectionManager.get_connection` to raise `ConnectionError` when the connection is closed
- Add unit tests covering active and inactive connection scenarios

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893d4b0c288832eae9098cc1ef8eb3a