### PR TITLE
Lista roles ao criar schema

### DIFF
--- a/gerenciador_postgres/controllers/schema_controller.py
+++ b/gerenciador_postgres/controllers/schema_controller.py
@@ -14,6 +14,9 @@ class SchemaController(QObject):
     def list_schemas(self):
         return self.schema_manager.list_schemas()
 
+    def list_roles(self):
+        return self.schema_manager.list_roles()
+
     def create_schema(self, name: str, owner: str | None = None):
         try:
             result = self.schema_manager.create_schema(name, owner)

--- a/gerenciador_postgres/gui/schema_view.py
+++ b/gerenciador_postgres/gui/schema_view.py
@@ -64,9 +64,25 @@ class SchemaView(QWidget):
         name, ok = QInputDialog.getText(self, "Novo Schema", "Nome do schema:")
         if not ok or not name:
             return
-        owner, ok2 = QInputDialog.getText(self, "Proprietário", "Owner (opcional):")
-        if not ok2:
-            owner = None
+        owner = None
+        roles = []
+        if self.controller:
+            try:
+                roles = self.controller.list_roles()
+            except Exception as e:
+                if self.logger:
+                    self.logger.error(f"Falha ao listar roles: {e}")
+        if roles:
+            items = [""] + roles
+            owner, ok2 = QInputDialog.getItem(
+                self, "Proprietário", "Owner (opcional):", items, 0, False
+            )
+            if not ok2:
+                owner = None
+        else:
+            owner, ok2 = QInputDialog.getText(self, "Proprietário", "Owner (opcional):")
+            if not ok2:
+                owner = None
         try:
             self.controller.create_schema(name, owner or None)
             QMessageBox.information(self, "Sucesso", f"Schema '{name}' criado.")

--- a/gerenciador_postgres/schema_manager.py
+++ b/gerenciador_postgres/schema_manager.py
@@ -120,3 +120,10 @@ class SchemaManager:
             self.logger.error(f"[{self.operador}] Erro ao listar schemas: {e}")
             return []
 
+    def list_roles(self) -> list[str]:
+        try:
+            return self.dao.list_roles()
+        except Exception as e:
+            self.logger.error(f"[{self.operador}] Erro ao listar roles: {e}")
+            return []
+

--- a/tests/test_db_manager_schema.py
+++ b/tests/test_db_manager_schema.py
@@ -1,0 +1,60 @@
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from gerenciador_postgres.db_manager import DBManager
+
+
+class DummyCursor:
+    def __init__(self, roles):
+        self.roles = roles
+        self.result = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql, params=None):
+        if "SELECT 1 FROM pg_roles" in sql:
+            owner = params[0]
+            self.result = [(1,)] if owner in self.roles else []
+        elif "SELECT rolname FROM pg_roles" in sql:
+            self.result = [(r,) for r in self.roles]
+        else:
+            self.result = []
+
+    def fetchone(self):
+        return self.result[0] if self.result else None
+
+    def fetchall(self):
+        return self.result
+
+
+class DummyConn:
+    def __init__(self, roles):
+        self.roles = roles
+
+    def cursor(self):
+        return DummyCursor(self.roles)
+
+
+class DBManagerSchemaTests(unittest.TestCase):
+    def setUp(self):
+        self.conn = DummyConn(["postgres", "Arthur"])
+        self.dbm = DBManager(self.conn)
+
+    def test_create_schema_owner_exists(self):
+        # Deve executar sem levantar exceção
+        self.dbm.create_schema("Lixo", "Arthur")
+
+    def test_create_schema_owner_missing(self):
+        with self.assertRaises(ValueError):
+            self.dbm.create_schema("Lixo", "NaoExiste")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -29,11 +29,14 @@ class DummyConn:
             def __exit__(self_inner, exc_type, exc, tb):
                 pass
 
-            def execute(self_inner, *args, **kwargs):
-                pass
+            def execute(self_inner, sql, params=None):
+                if "pg_has_role" in sql:
+                    self_inner._result = [(True,)]
+                else:
+                    self_inner._result = [(None,)]
 
             def fetchone(self_inner):
-                return (None,)
+                return self_inner._result[0]
 
         return DummyCursor()
 


### PR DESCRIPTION
## Summary
- Valida se o owner existe ao criar schemas e informa roles disponíveis
- Exibe lista de roles na interface de criação de schemas
- Adiciona testes para validar owners inexistentes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893d6b6b3a4832e81cb629e508f7104