### PR TITLE
Add consistent window icons to Qt interface

### DIFF
--- a/Rodar.py
+++ b/Rodar.py
@@ -1,6 +1,6 @@
 from gerenciador_postgres.gui.main_window import MainWindow
 from PyQt6.QtWidgets import QApplication, QSplashScreen
-from PyQt6.QtGui import QPixmap
+from PyQt6.QtGui import QPixmap, QIcon
 from PyQt6.QtCore import QTimer
 from pathlib import Path
 import subprocess
@@ -9,8 +9,8 @@ import sys
 
 def main():
     app = QApplication(sys.argv)
-
     assets_dir = Path(__file__).resolve().parent / "assets"
+    app.setWindowIcon(QIcon(str(assets_dir / "icone.png")))
     splash_path = assets_dir / "splash.png"
     if not splash_path.exists():
         subprocess.run([sys.executable, str(assets_dir / "create_splash.py")], check=True)

--- a/gerenciador_postgres/gui/connection_dialog.py
+++ b/gerenciador_postgres/gui/connection_dialog.py
@@ -14,6 +14,7 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtGui import QIcon, QAction
 from PyQt6.QtCore import Qt, QThread, pyqtSignal
+from pathlib import Path
 try:
     import keyring
 except ImportError:
@@ -55,6 +56,8 @@ class ConnectionWorker(QThread):
 class ConnectionDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
+        assets_dir = Path(__file__).resolve().parents[2] / "assets"
+        self.setWindowIcon(QIcon(str(assets_dir / "icone.png")))
         self.setWindowTitle("Conectar ao Banco de Dados")
         self.setModal(True)
         self.resize(400, 220)

--- a/gerenciador_postgres/gui/help_dialog.py
+++ b/gerenciador_postgres/gui/help_dialog.py
@@ -1,10 +1,14 @@
 from PyQt6.QtWidgets import QDialog, QVBoxLayout, QTextBrowser
+from PyQt6.QtGui import QIcon
+from pathlib import Path
 
 
 class HelpDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
+        assets_dir = Path(__file__).resolve().parents[2] / "assets"
         self.setWindowTitle("Ajuda")
+        self.setWindowIcon(QIcon(str(assets_dir / "icone.png")))
         layout = QVBoxLayout(self)
         self.browser = QTextBrowser(self)
         self.browser.setHtml("<p>Ajuda inicial</p>")

--- a/gerenciador_postgres/gui/main_window.py
+++ b/gerenciador_postgres/gui/main_window.py
@@ -1,7 +1,8 @@
 from PyQt6.QtWidgets import QMainWindow, QLabel, QMenuBar
 from PyQt6.QtWidgets import QStatusBar, QApplication, QMessageBox, QDialog
-from PyQt6.QtGui import QAction
+from PyQt6.QtGui import QAction, QIcon
 from PyQt6.QtCore import Qt
+from pathlib import Path
 from .connection_dialog import ConnectionDialog
 from ..db_manager import DBManager
 from ..role_manager import RoleManager
@@ -14,6 +15,8 @@ from ..logger import setup_logger
 class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
+        assets_dir = Path(__file__).resolve().parents[2] / "assets"
+        self.setWindowIcon(QIcon(str(assets_dir / "icone.png")))
         self.setWindowTitle("Gerenciador PostgreSQL")
         self.resize(900, 600)
         self._setup_menu()

--- a/gerenciador_postgres/gui/privileges_view.py
+++ b/gerenciador_postgres/gui/privileges_view.py
@@ -1,8 +1,12 @@
 from PyQt6.QtWidgets import QWidget, QVBoxLayout, QComboBox, QPushButton, QTreeWidget, QTreeWidgetItem, QLabel, QHBoxLayout
+from PyQt6.QtGui import QIcon
+from pathlib import Path
 
 class PrivilegesView(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
+        assets_dir = Path(__file__).resolve().parents[2] / "assets"
+        self.setWindowIcon(QIcon(str(assets_dir / "icone.png")))
         self._setup_ui()
 
     def _setup_ui(self):

--- a/gerenciador_postgres/gui/schema_view.py
+++ b/gerenciador_postgres/gui/schema_view.py
@@ -7,11 +7,15 @@ from PyQt6.QtWidgets import (
     QInputDialog,
     QMessageBox,
 )
+from PyQt6.QtGui import QIcon
+from pathlib import Path
 
 
 class SchemaView(QWidget):
     def __init__(self, parent=None, controller=None, logger=None):
         super().__init__(parent)
+        assets_dir = Path(__file__).resolve().parents[2] / "assets"
+        self.setWindowIcon(QIcon(str(assets_dir / "icone.png")))
         self.controller = controller
         self.logger = logger
         self.setWindowTitle("Gerenciador de Schemas")

--- a/gerenciador_postgres/gui/users_view.py
+++ b/gerenciador_postgres/gui/users_view.py
@@ -1,12 +1,27 @@
-from PyQt6.QtWidgets import (QWidget, QSplitter, QLineEdit, QListWidget, QTabWidget,
-                             QVBoxLayout, QToolBar, QPushButton, QLabel, QListWidgetItem,
-                             QInputDialog, QMessageBox)
+from PyQt6.QtWidgets import (
+    QWidget,
+    QSplitter,
+    QLineEdit,
+    QListWidget,
+    QTabWidget,
+    QVBoxLayout,
+    QToolBar,
+    QPushButton,
+    QLabel,
+    QListWidgetItem,
+    QInputDialog,
+    QMessageBox,
+)
 from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QIcon
+from pathlib import Path
 
 
 class UsersView(QWidget):
     def __init__(self, parent=None, controller=None):
         super().__init__(parent)
+        assets_dir = Path(__file__).resolve().parents[2] / "assets"
+        self.setWindowIcon(QIcon(str(assets_dir / "icone.png")))
         self.controller = controller
         self.setWindowTitle("Gerenciador de Usuários e Grupos")
         self._setup_ui()


### PR DESCRIPTION
## Summary
- Set application icon in `Rodar.py`
- Apply window icon to `MainWindow`, `ConnectionDialog`, `HelpDialog`, `UsersView`, `SchemaView`, and `PrivilegesView`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893faa6d9d8832e96947c6b1c258606