### PR TITLE
Add user/group privilege utilities and bulk operations

### DIFF
--- a/tests/test_db_manager_user_groups.py
+++ b/tests/test_db_manager_user_groups.py
@@ -1,0 +1,37 @@
+import unittest
+
+from gerenciador_postgres.db_manager import DBManager
+
+
+class DummyCursor:
+    def __init__(self):
+        self.executed = None
+        self.result = [("grp1",), ("grp2",)]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql, params=None):
+        self.executed = (sql, params)
+
+    def fetchall(self):
+        return self.result
+
+
+class DummyConn:
+    def cursor(self):
+        return DummyCursor()
+
+
+class DBManagerUserGroupTests(unittest.TestCase):
+    def test_list_user_groups(self):
+        dbm = DBManager(DummyConn())
+        groups = dbm.list_user_groups("bob")
+        self.assertEqual(groups, ["grp1", "grp2"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_role_manager_extra.py
+++ b/tests/test_role_manager_extra.py
@@ -1,0 +1,75 @@
+import logging
+import unittest
+
+from gerenciador_postgres.role_manager import RoleManager
+
+
+class DummyConn:
+    def __init__(self):
+        self.committed = False
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        pass
+
+
+class DummyDAO:
+    def __init__(self):
+        self.conn = DummyConn()
+        self.inserted = []
+        self.granted = None
+        self.revoked = None
+        self.groups = {"alice": ["grp_a", "grp_b"]}
+
+    def find_user_by_name(self, username):
+        return None
+
+    def insert_user(self, username, password):
+        self.inserted.append((username, password))
+
+    def list_user_groups(self, username):
+        return self.groups.get(username, [])
+
+    def grant_privileges(self, role, schema, table, privileges):
+        self.granted = (role, schema, table, privileges)
+
+    def revoke_privileges(self, role, schema, table, privileges):
+        self.revoked = (role, schema, table, privileges)
+
+
+class RoleManagerExtraTests(unittest.TestCase):
+    def setUp(self):
+        self.dao = DummyDAO()
+        logger = logging.getLogger("test")
+        self.rm = RoleManager(self.dao, logger)
+
+    def test_bulk_create_users(self):
+        users = {"u1": "p1", "u2": "p2"}
+        created = self.rm.bulk_create_users(users)
+        self.assertEqual(created, ["u1", "u2"])
+        self.assertEqual(self.dao.inserted, [("u1", "p1"), ("u2", "p2")])
+        self.assertTrue(self.dao.conn.committed)
+
+    def test_list_user_groups(self):
+        groups = self.rm.list_user_groups("alice")
+        self.assertEqual(groups, ["grp_a", "grp_b"])
+
+    def test_grant_and_revoke(self):
+        privs = {"SELECT", "INSERT"}
+        self.assertTrue(
+            self.rm.grant_privileges("grp_a", "public", "t1", privs)
+        )
+        self.assertEqual(self.dao.granted, ("grp_a", "public", "t1", privs))
+        self.assertTrue(self.dao.conn.committed)
+        self.dao.conn.committed = False
+        self.assertTrue(
+            self.rm.revoke_privileges("grp_a", "public", "t1", privs)
+        )
+        self.assertEqual(self.dao.revoked, ("grp_a", "public", "t1", privs))
+        self.assertTrue(self.dao.conn.committed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Support cascading role removal and listing user groups in DB layer
- Add bulk user creation and privilege grant/revoke helpers in RoleManager
- Cover new utilities with unit tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894d4bc561c832eb001a21b92578a24