### PR TITLE
Gracefully handle missing keyring and improve connection diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# IFSC SGBD
+
+Aplicação para gerenciar conexões com o PostgreSQL.
+
+## Dependências opcionais
+
+- **keyring** – permite salvar senhas com segurança. Instalação:
+
+  ```bash
+  pip install keyring
+  ```
+
+A aplicação funciona sem esta dependência, porém as opções de salvar senha ficarão desabilitadas.


### PR DESCRIPTION
## Summary
- warn when `keyring` is missing and disable password storage features
- show progress dialog while testing connections and allow cancellation
- provide actionable tips when a connection attempt fails
- document optional `keyring` dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894f6a5b5e0832ead3601bccc386ae5