### PR TITLE
Handle missing config by generating default

### DIFF
--- a/gerenciador_postgres/config_manager.py
+++ b/gerenciador_postgres/config_manager.py
@@ -1,12 +1,23 @@
 import yaml
-from .path_config import CONFIG_DIR
+from .path_config import CONFIG_DIR, BASE_DIR
 
 CONFIG_FILE = CONFIG_DIR / 'config.yml'
+DEFAULT_CONFIG = {
+    'log_path': str(BASE_DIR / 'logs' / 'app.log'),
+    'log_level': 'INFO'
+}
 
 def load_config():
+    if not CONFIG_FILE.exists():
+        CONFIG_DIR.mkdir(exist_ok=True)
+        with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
+            yaml.safe_dump(DEFAULT_CONFIG, f, allow_unicode=True)
+        return DEFAULT_CONFIG.copy()
     with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
-        return yaml.safe_load(f)
+        data = yaml.safe_load(f) or {}
+    return {**DEFAULT_CONFIG, **data}
 
 def save_config(data):
+    CONFIG_DIR.mkdir(exist_ok=True)
     with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
         yaml.safe_dump(data, f, allow_unicode=True)

--- a/gerenciador_postgres/logger.py
+++ b/gerenciador_postgres/logger.py
@@ -5,10 +5,8 @@ from .config_manager import load_config
 import os
 
 def setup_logger(name: str = 'app'):
-    config = None
     try:
-        from .config_manager import load_config as _load_config
-        config = _load_config()
+        config = load_config()
     except Exception:
         config = {'log_path': str(BASE_DIR / 'logs' / 'app.log'), 'log_level': 'INFO'}
     log_path = config.get('log_path', str(BASE_DIR / 'logs' / 'app.log'))

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,0 +1,14 @@
+from gerenciador_postgres import config_manager
+
+
+def test_load_config_creates_file(tmp_path, monkeypatch):
+    config_dir = tmp_path / "config"
+    config_file = config_dir / "config.yml"
+    monkeypatch.setattr(config_manager, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(config_manager, "CONFIG_FILE", config_file)
+
+    data = config_manager.load_config()
+
+    assert config_file.exists()
+    assert data["log_level"] == "INFO"
+    assert "log_path" in data


### PR DESCRIPTION
## Summary
- Automatically create a default `config.yml` when missing
- Simplify logger initialization to rely on new config loader
- Add regression test for configuration file creation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68950986ac84832e98f39cda50c9c0cc