### PR TITLE
Handle missing QIcon.FallbackThemeIcon in ConnectionDialog

### DIFF
--- a/gerenciador_postgres/gui/connection_dialog.py
+++ b/gerenciador_postgres/gui/connection_dialog.py
@@ -11,6 +11,7 @@ from PyQt6.QtWidgets import (
     QPushButton,
     QCheckBox,
     QProgressDialog,
+    QStyle,
 )
 from PyQt6.QtGui import QIcon, QAction
 from PyQt6.QtCore import Qt, QThread, pyqtSignal
@@ -136,8 +137,10 @@ class ConnectionDialog(QDialog):
         self.toggle_password_action.triggered.connect(self.toggle_password_visibility)
         self.txtPassword.addAction(self.toggle_password_action, QLineEdit.ActionPosition.TrailingPosition)
         try:
-            self.toggle_password_action.setIcon(self.style().standardIcon(getattr(self.style(), 'SP_DialogApplyButton', QIcon.FallbackThemeIcon)))
-        except:
+            self.toggle_password_action.setIcon(
+                self.style().standardIcon(QStyle.StandardPixmap.SP_DialogApplyButton)
+            )
+        except Exception:
             pass
 
         form_layout.addLayout(password_layout)


### PR DESCRIPTION
## Summary
- Avoid using nonexistent `QIcon.FallbackThemeIcon` when setting the password toggle icon
- Import `QStyle` and use `QStyle.StandardPixmap.SP_DialogApplyButton`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68950d9eafc0832eb9d65ee63f9199cc