### PR TITLE
Fix password icon setup to avoid AttributeError

### DIFF
--- a/gerenciador_postgres/gui/connection_dialog.py
+++ b/gerenciador_postgres/gui/connection_dialog.py
@@ -136,10 +136,9 @@ class ConnectionDialog(QDialog):
         self.toggle_password_action.setCheckable(True)
         self.toggle_password_action.triggered.connect(self.toggle_password_visibility)
         self.txtPassword.addAction(self.toggle_password_action, QLineEdit.ActionPosition.TrailingPosition)
-        try:
-            self.toggle_password_action.setIcon(self.style().standardIcon(getattr(self.style(), 'SP_DialogApplyButton', QIcon.FallbackThemeIcon)))
-        except:
-            pass
+        self.toggle_password_action.setIcon(
+            self.style().standardIcon(QStyle.StandardPixmap.SP_DialogApplyButton)
+        )
 
         form_layout.addLayout(password_layout)
         layout.addLayout(form_layout)


### PR DESCRIPTION
## Summary
- Replace `QIcon.FallbackThemeIcon` usage with `QStyle.StandardPixmap.SP_DialogApplyButton`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689512a100bc832e8c24647828fd222b