### PR TITLE
Add user expiration and bulk creation

### DIFF
--- a/gerenciador_postgres/controllers/users_controller.py
+++ b/gerenciador_postgres/controllers/users_controller.py
@@ -16,10 +16,15 @@ class UsersController(QObject):
         groups = self.role_manager.list_groups()
         return users, groups
 
-    def create_user(self, username: str, password: str):
-        result = self.role_manager.create_user(username, password)
+    def create_user(self, username: str, password: str, valid_until: str | None = None):
+        result = self.role_manager.create_user(username, password, valid_until)
         self.data_changed.emit()
         return result
+
+    def create_users_batch(self, users_data):
+        results = self.role_manager.create_users_batch(users_data)
+        self.data_changed.emit()
+        return results
 
     def create_group(self, group_name: str):
         result = self.role_manager.create_group(group_name)

--- a/gerenciador_postgres/db_manager.py
+++ b/gerenciador_postgres/db_manager.py
@@ -25,14 +25,22 @@ class DBManager:
                 return User(username=row[0], oid=row[1], valid_until=row[2], can_login=row[3])
             return None
 
-    def insert_user(self, username: str, password_hash: str):
+    def insert_user(self, username: str, password_hash: str, valid_until: str | None = None):
         with self.conn.cursor() as cur:
-            cur.execute(
-                sql.SQL("CREATE ROLE {} WITH LOGIN PASSWORD %s").format(
-                    sql.Identifier(username)
-                ),
-                (password_hash,),
-            )
+            if valid_until:
+                cur.execute(
+                    sql.SQL(
+                        "CREATE ROLE {} WITH LOGIN PASSWORD %s VALID UNTIL %s"
+                    ).format(sql.Identifier(username)),
+                    (password_hash, valid_until),
+                )
+            else:
+                cur.execute(
+                    sql.SQL("CREATE ROLE {} WITH LOGIN PASSWORD %s").format(
+                        sql.Identifier(username)
+                    ),
+                    (password_hash,),
+                )
 
     def update_user(self, username: str, **fields):
         with self.conn.cursor() as cur:

--- a/tests/test_user_group_management.py
+++ b/tests/test_user_group_management.py
@@ -9,6 +9,7 @@ class DummyDAO:
     def __init__(self):
         self.conn = DummyConn()
         self.members = {}
+        self.users = {}
 
     def list_user_groups(self, username):
         return sorted(self.members.get(username, set()))
@@ -22,6 +23,15 @@ class DummyDAO:
 
     def list_groups(self):
         return ["grp_a", "grp_b"]
+
+    def find_user_by_name(self, username):
+        return self.users.get(username)
+
+    def insert_user(self, username, password, valid_until=None):
+        self.users[username] = {
+            'password': password,
+            'valid_until': valid_until,
+        }
 
 
 class DummyConn:
@@ -45,6 +55,19 @@ class UserGroupManagementTests(unittest.TestCase):
         self.assertEqual(self.uc.list_user_groups("alice"), ["grp_a"])
         self.assertTrue(self.uc.remove_user_from_group("alice", "grp_a"))
         self.assertEqual(self.uc.list_user_groups("alice"), [])
+
+    def test_create_user_with_expiration(self):
+        self.uc.create_user('alice', 'pw', '2025-12-31')
+        self.assertEqual(self.dao.users['alice']['valid_until'], '2025-12-31')
+
+    def test_create_users_batch(self):
+        data = [
+            ('bob', 'pw1', None),
+            ('carol', 'pw2', '2024-06-30'),
+        ]
+        created = self.uc.create_users_batch(data)
+        self.assertEqual(set(created), {'bob', 'carol'})
+        self.assertEqual(self.dao.users['carol']['valid_until'], '2024-06-30')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow setting `VALID UNTIL` when creating users
- support creating users in batch via controller and GUI
- add tests for expiration and batch user creation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68951f061910832ea2fa175904711ed7