### PR TITLE
refactor: separate user and group management

### DIFF
--- a/gerenciador_postgres/controllers/__init__.py
+++ b/gerenciador_postgres/controllers/__init__.py
@@ -1,6 +1,7 @@
 from .users_controller import UsersController
+from .groups_controller import GroupsController
 from .schema_controller import SchemaController
 from .audit_controller import AuditController
 
-__all__ = ["UsersController", "SchemaController", "AuditController"]
+__all__ = ["UsersController", "GroupsController", "SchemaController", "AuditController"]
 

--- a/gerenciador_postgres/controllers/groups_controller.py
+++ b/gerenciador_postgres/controllers/groups_controller.py
@@ -1,0 +1,56 @@
+from PyQt6.QtCore import QObject, pyqtSignal
+from config.permission_templates import PERMISSION_TEMPLATES
+
+
+class GroupsController(QObject):
+    """Controller dedicado às operações de grupos e privilégios."""
+
+    data_changed = pyqtSignal()
+
+    def __init__(self, role_manager):
+        super().__init__()
+        self.role_manager = role_manager
+
+    # ---------------------------------------------------------------
+    # Operações de grupos
+    # ---------------------------------------------------------------
+    def list_groups(self):
+        return self.role_manager.list_groups()
+
+    def create_group(self, group_name: str):
+        result = self.role_manager.create_group(group_name)
+        self.data_changed.emit()
+        return result
+
+    def delete_group(self, group_name: str) -> bool:
+        success = self.role_manager.delete_group(group_name)
+        if success:
+            self.data_changed.emit()
+        return success
+
+    def delete_group_and_members(self, group_name: str) -> bool:
+        success = self.role_manager.delete_group_and_members(group_name)
+        if success:
+            self.data_changed.emit()
+        return success
+
+    # ---------------------------------------------------------------
+    # Operações de privilégios
+    # ---------------------------------------------------------------
+    def get_schema_tables(self):
+        return self.role_manager.list_tables_by_schema()
+
+    def list_privilege_templates(self):
+        return PERMISSION_TEMPLATES
+
+    def apply_group_privileges(self, group_name: str, privileges):
+        success = self.role_manager.set_group_privileges(group_name, privileges)
+        if success:
+            self.data_changed.emit()
+        return success
+
+    def apply_template_to_group(self, group_name: str, template: str):
+        success = self.role_manager.apply_template_to_group(group_name, template)
+        if success:
+            self.data_changed.emit()
+        return success

--- a/gerenciador_postgres/controllers/users_controller.py
+++ b/gerenciador_postgres/controllers/users_controller.py
@@ -1,9 +1,8 @@
 from PyQt6.QtCore import QObject, pyqtSignal
-from config.permission_templates import PERMISSION_TEMPLATES
 
 
 class UsersController(QObject):
-    """Controller que orquestra operações de usuário e grupo."""
+    """Controller responsável apenas pelas operações de usuário."""
 
     data_changed = pyqtSignal()
 
@@ -11,10 +10,11 @@ class UsersController(QObject):
         super().__init__()
         self.role_manager = role_manager
 
-    def list_entities(self):
-        users = self.role_manager.list_users()
-        groups = self.role_manager.list_groups()
-        return users, groups
+    # ------------------------------------------------------------------
+    # Operações de usuário
+    # ------------------------------------------------------------------
+    def list_users(self):
+        return self.role_manager.list_users()
 
     def create_user(self, username: str, password: str, valid_until: str | None = None):
         result = self.role_manager.create_user(username, password, valid_until)
@@ -26,36 +26,8 @@ class UsersController(QObject):
         self.data_changed.emit()
         return results
 
-    def create_group(self, group_name: str):
-        result = self.role_manager.create_group(group_name)
-        self.data_changed.emit()
-        return result
-
-    def list_groups(self):
-        """Retorna lista de grupos existentes."""
-        return self.role_manager.list_groups()
-
-    def add_user_to_group(self, username: str, group_name: str) -> bool:
-        """Associa um usuário a um grupo."""
-        success = self.role_manager.add_user_to_group(username, group_name)
-        if success:
-            self.data_changed.emit()
-        return success
-
     def delete_user(self, username: str) -> bool:
         success = self.role_manager.delete_user(username)
-        if success:
-            self.data_changed.emit()
-        return success
-
-    def delete_group(self, group_name: str) -> bool:
-        success = self.role_manager.delete_group(group_name)
-        if success:
-            self.data_changed.emit()
-        return success
-
-    def delete_group_and_members(self, group_name: str) -> bool:
-        success = self.role_manager.delete_group_and_members(group_name)
         if success:
             self.data_changed.emit()
         return success
@@ -63,8 +35,9 @@ class UsersController(QObject):
     def change_password(self, username: str, new_password: str) -> bool:
         return self.role_manager.change_password(username, new_password)
 
-    # --- Métodos de turmas ----------------------------------------------
-
+    # ------------------------------------------------------------------
+    # Operações relativas a grupos para um usuário
+    # ------------------------------------------------------------------
     def list_groups(self):
         return self.role_manager.list_groups()
 
@@ -79,30 +52,6 @@ class UsersController(QObject):
 
     def remove_user_from_group(self, username: str, group_name: str) -> bool:
         success = self.role_manager.remove_user_from_group(username, group_name)
-        if success:
-            self.data_changed.emit()
-        return success
-
-    # --- Novos métodos de privilégios ----------------------------------
-
-    def get_schema_tables(self):
-        """Retorna dicionário de schemas e suas tabelas."""
-        return self.role_manager.list_tables_by_schema()
-
-    def list_privilege_templates(self):
-        """Templates simples de conjunto de permissões."""
-        return PERMISSION_TEMPLATES
-
-    def apply_group_privileges(self, group_name: str, privileges):
-        """Encaminha atualização de privilégios ao RoleManager."""
-        success = self.role_manager.set_group_privileges(group_name, privileges)
-        if success:
-            self.data_changed.emit()
-        return success
-
-    def apply_template_to_group(self, group_name: str, template: str):
-        """Aplica um template de permissões diretamente a um grupo."""
-        success = self.role_manager.apply_template_to_group(group_name, template)
         if success:
             self.data_changed.emit()
         return success

--- a/gerenciador_postgres/gui/groups_view.py
+++ b/gerenciador_postgres/gui/groups_view.py
@@ -1,12 +1,19 @@
 from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
+    QHBoxLayout,
+    QListWidget,
+    QListWidgetItem,
     QTreeWidget,
     QTreeWidgetItem,
     QComboBox,
     QPushButton,
     QLabel,
-    QHBoxLayout,
+    QSplitter,
+    QToolBar,
+    QInputDialog,
+    QMessageBox,
+    QLineEdit,
 )
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QIcon
@@ -14,50 +21,148 @@ from pathlib import Path
 
 
 class GroupsView(QWidget):
-    """Interface para edição de privilégios de grupos."""
+    """Janela para gerenciamento de grupos e seus privilégios."""
 
-    def __init__(self, parent=None, controller=None, group_name: str = ""):
+    def __init__(self, parent=None, controller=None):
         super().__init__(parent)
         assets_dir = Path(__file__).resolve().parents[2] / "assets"
         self.setWindowIcon(QIcon(str(assets_dir / "icone.png")))
         self.controller = controller
-        self.group_name = group_name
+        self.current_group = None
         self.templates = {}
         self._setup_ui()
-        self._load_templates()
-        self._populate_tree()
+        self._connect_signals()
+        if self.controller:
+            self.controller.data_changed.connect(self.refresh_groups)
+        self.refresh_groups()
 
+    # ------------------------------------------------------------------
     def _setup_ui(self):
         layout = QVBoxLayout(self)
+        self.splitter = QSplitter(Qt.Orientation.Horizontal)
+
+        # Left panel: list of groups
+        left_panel = QWidget()
+        left_layout = QVBoxLayout(left_panel)
+        self.toolbar = QToolBar()
+        self.btnNewGroup = QPushButton("Novo Grupo")
+        self.btnDeleteGroup = QPushButton("Excluir Grupo")
+        self.toolbar.addWidget(self.btnNewGroup)
+        self.toolbar.addWidget(self.btnDeleteGroup)
+        left_layout.addWidget(self.toolbar)
+        self.lstGroups = QListWidget()
+        left_layout.addWidget(self.lstGroups)
+        self.splitter.addWidget(left_panel)
+
+        # Right panel: privileges
+        right_panel = QWidget()
+        right_layout = QVBoxLayout(right_panel)
         top = QHBoxLayout()
         top.addWidget(QLabel("Template:"))
         self.cmbTemplates = QComboBox()
         self.btnApplyTemplate = QPushButton("Aplicar")
         top.addWidget(self.cmbTemplates)
         top.addWidget(self.btnApplyTemplate)
-        layout.addLayout(top)
+        right_layout.addLayout(top)
 
         self.treePrivileges = QTreeWidget()
-        self.treePrivileges.setHeaderLabels(
-            ["Schema/Tabela", "SELECT", "INSERT", "UPDATE", "DELETE"]
-        )
-        layout.addWidget(self.treePrivileges)
-
+        self.treePrivileges.setHeaderLabels([
+            "Schema/Tabela",
+            "SELECT",
+            "INSERT",
+            "UPDATE",
+            "DELETE",
+        ])
+        right_layout.addWidget(self.treePrivileges)
         self.btnSave = QPushButton("Salvar")
-        layout.addWidget(self.btnSave)
+        right_layout.addWidget(self.btnSave)
+        self.splitter.addWidget(right_panel)
+
+        layout.addWidget(self.splitter)
         self.setLayout(layout)
 
+        # Disable privilege controls until a group is selected
+        self.treePrivileges.setEnabled(False)
+        self.btnApplyTemplate.setEnabled(False)
+        self.btnSave.setEnabled(False)
+
+    def _connect_signals(self):
+        self.btnNewGroup.clicked.connect(self._on_new_group)
+        self.btnDeleteGroup.clicked.connect(self._on_delete_group)
+        self.lstGroups.currentItemChanged.connect(self._on_group_selected)
         self.btnApplyTemplate.clicked.connect(self._apply_template)
         self.btnSave.clicked.connect(self._save_privileges)
+
+    # ------------------------------------------------------------------
+    def refresh_groups(self):
+        self.lstGroups.clear()
+        if not self.controller:
+            return
+        for grp in self.controller.list_groups():
+            self.lstGroups.addItem(QListWidgetItem(grp))
+        self._load_templates()
 
     def _load_templates(self):
         if not self.controller:
             return
         self.templates = self.controller.list_privilege_templates()
+        self.cmbTemplates.clear()
         self.cmbTemplates.addItems(self.templates.keys())
 
+    def _on_new_group(self):
+        name, ok = QInputDialog.getText(
+            self,
+            "Novo Grupo",
+            "Nome do grupo (deve começar com 'grp_'):",
+            QLineEdit.EchoMode.Normal,
+            "grp_",
+        )
+        if not ok or not name:
+            return
+        name = name.strip()
+        try:
+            self.controller.create_group(name)
+            QMessageBox.information(self, "Sucesso", f"Grupo '{name}' criado.")
+        except Exception as e:
+            QMessageBox.critical(self, "Erro", f"Não foi possível criar o grupo.\nMotivo: {e}")
+
+    def _on_delete_group(self):
+        item = self.lstGroups.currentItem()
+        if not item:
+            return
+        group = item.text()
+        reply = QMessageBox.question(
+            self,
+            "Confirmar Deleção",
+            f"Tem certeza que deseja excluir o grupo '{group}'?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            if self.controller.delete_group(group):
+                QMessageBox.information(
+                    self, "Sucesso", f"Grupo '{group}' excluído com sucesso."
+                )
+            else:
+                QMessageBox.critical(
+                    self, "Erro", "Não foi possível excluir o grupo."
+                )
+
+    def _on_group_selected(self, current, previous):
+        if not current:
+            self.current_group = None
+            self.treePrivileges.setEnabled(False)
+            self.btnApplyTemplate.setEnabled(False)
+            self.btnSave.setEnabled(False)
+            return
+        self.current_group = current.text()
+        self.treePrivileges.setEnabled(True)
+        self.btnApplyTemplate.setEnabled(True)
+        self.btnSave.setEnabled(True)
+        self._populate_tree()
+
     def _populate_tree(self):
-        if not self.controller:
+        if not self.controller or not self.current_group:
             return
         data = self.controller.get_schema_tables()
         self.treePrivileges.clear()
@@ -78,18 +183,42 @@ class GroupsView(QWidget):
         self.treePrivileges.expandAll()
 
     def _apply_template(self):
-        name = self.cmbTemplates.currentText()
-        perms = self.templates.get(name, set())
-        for i in range(self.treePrivileges.topLevelItemCount()):
-            schema_item = self.treePrivileges.topLevelItem(i)
-            for j in range(schema_item.childCount()):
-                table_item = schema_item.child(j)
-                for col, label in enumerate(["SELECT", "INSERT", "UPDATE", "DELETE"], start=1):
-                    state = Qt.CheckState.Checked if label in perms else Qt.CheckState.Unchecked
-                    table_item.setCheckState(col, state)
+        if not self.current_group:
+            return
+        template_name = self.cmbTemplates.currentText()
+        try:
+            success = self.controller.apply_template_to_group(
+                self.current_group, template_name
+            )
+            if success:
+                QMessageBox.information(
+                    self, "Sucesso", "Template aplicado com sucesso."
+                )
+                perms = self.templates.get(template_name, set())
+                for i in range(self.treePrivileges.topLevelItemCount()):
+                    schema_item = self.treePrivileges.topLevelItem(i)
+                    for j in range(schema_item.childCount()):
+                        table_item = schema_item.child(j)
+                        for col, label in enumerate(
+                            ["SELECT", "INSERT", "UPDATE", "DELETE"], start=1
+                        ):
+                            state = (
+                                Qt.CheckState.Checked
+                                if label in perms
+                                else Qt.CheckState.Unchecked
+                            )
+                            table_item.setCheckState(col, state)
+            else:
+                QMessageBox.critical(
+                    self, "Erro", "Falha ao aplicar o template ao grupo."
+                )
+        except Exception as e:
+            QMessageBox.critical(
+                self, "Erro", f"Não foi possível aplicar o template: {e}"
+            )
 
     def _save_privileges(self):
-        if not self.controller or not self.group_name:
+        if not self.current_group:
             return
         privileges: dict[str, dict[str, set[str]]] = {}
         for i in range(self.treePrivileges.topLevelItemCount()):
@@ -104,4 +233,9 @@ class GroupsView(QWidget):
                         perms.add(label)
                 if perms:
                     privileges.setdefault(schema, {})[table] = perms
-        self.controller.apply_group_privileges(self.group_name, privileges)
+        if self.controller.apply_group_privileges(self.current_group, privileges):
+            QMessageBox.information(self, "Sucesso", "Privilégios atualizados.")
+        else:
+            QMessageBox.critical(
+                self, "Erro", "Falha ao salvar os privilégios do grupo."
+            )


### PR DESCRIPTION
## Summary
- isolate user-specific logic in UsersController
- add GroupsController and GroupsView for group and privilege management
- update menus and views so users and groups are managed in separate windows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68952ef6a99c832e920869a65ed100e7