### PR TITLE
Refactor user management view and batch creation

### DIFF
--- a/gerenciador_postgres/controllers/users_controller.py
+++ b/gerenciador_postgres/controllers/users_controller.py
@@ -21,8 +21,18 @@ class UsersController(QObject):
         self.data_changed.emit()
         return result
 
-    def create_users_batch(self, users_data):
-        results = self.role_manager.create_users_batch(users_data)
+    def create_users_batch(self, users_data: list, valid_until: str | None = None):
+        """Cria múltiplos usuários de uma vez.
+
+        Parameters
+        ----------
+        users_data: list
+            Lista de tuplas ``(matricula, nome_completo)``.
+        valid_until: str | None
+            Data de expiração a ser aplicada a todos os usuários ou ``None``.
+        """
+
+        results = self.role_manager.create_users_batch(users_data, valid_until)
         self.data_changed.emit()
         return results
 

--- a/tests/test_user_group_management.py
+++ b/tests/test_user_group_management.py
@@ -62,12 +62,13 @@ class UserGroupManagementTests(unittest.TestCase):
 
     def test_create_users_batch(self):
         data = [
-            ('bob', 'pw1', None),
-            ('carol', 'pw2', '2024-06-30'),
+            ("111", "Bob Silva"),
+            ("222", "Carol Dias"),
         ]
-        created = self.uc.create_users_batch(data)
-        self.assertEqual(set(created), {'bob', 'carol'})
-        self.assertEqual(self.dao.users['carol']['valid_until'], '2024-06-30')
+        created = self.uc.create_users_batch(data, "2024-06-30")
+        self.assertEqual(set(created), {"bob.silva", "carol.dias"})
+        self.assertEqual(self.dao.users["bob.silva"]["password"], "111")
+        self.assertEqual(self.dao.users["carol.dias"]["valid_until"], "2024-06-30")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Integrate group management directly into the user details pane
- Support batch user creation from student lists with optional expiration
- Generate usernames from full names while handling duplicates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68953893ac04832ebee1565b8ff1cf70