### PR TITLE
Fix schema tristate handling in groups view

### DIFF
--- a/gerenciador_postgres/gui/groups_view.py
+++ b/gerenciador_postgres/gui/groups_view.py
@@ -168,10 +168,9 @@ class GroupsView(QWidget):
         self.treePrivileges.clear()
         for schema, tables in data.items():
             schema_item = QTreeWidgetItem([schema])
+            # Only set the tristate flag so the parent reflects its children.
             schema_item.setFlags(
-                schema_item.flags()
-                | Qt.ItemFlag.ItemIsTristate
-                | Qt.ItemFlag.ItemIsUserCheckable
+                schema_item.flags() | Qt.ItemFlag.ItemIsTristate
             )
             self.treePrivileges.addTopLevelItem(schema_item)
             for table in tables:


### PR DESCRIPTION
## Summary
- prevent top-level schema items from being user-checkable so tristate state mirrors children

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68953e553580832eb10997a2363d10fe