### PR TITLE
Use AutoTristate flag for schema items

### DIFF
--- a/gerenciador_postgres/gui/groups_view.py
+++ b/gerenciador_postgres/gui/groups_view.py
@@ -170,7 +170,7 @@ class GroupsView(QWidget):
             schema_item = QTreeWidgetItem([schema])
             # Only set the tristate flag so the parent reflects its children.
             schema_item.setFlags(
-                schema_item.flags() | Qt.ItemFlag.ItemIsTristate
+                schema_item.flags() | Qt.ItemFlag.ItemIsAutoTristate
             )
             self.treePrivileges.addTopLevelItem(schema_item)
             for table in tables:


### PR DESCRIPTION
## Summary
- Ensure schema-level items in groups view use `ItemIsAutoTristate` rather than `ItemIsTristate`
- Keep `ItemIsUserCheckable` only for table items

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689544243f98832e9f84b99ebdb26c75