### PR TITLE
Add dialog button box to user management view

### DIFF
--- a/gerenciador_postgres/gui/users_view.py
+++ b/gerenciador_postgres/gui/users_view.py
@@ -173,6 +173,13 @@ class UsersView(QWidget):
         self.splitter.addWidget(self.bottomPanel)
 
         layout.addWidget(self.splitter)
+
+        self.buttonBox = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Save
+            | QDialogButtonBox.StandardButton.Close
+        )
+        layout.addWidget(self.buttonBox)
+
         self.setLayout(layout)
 
     def _connect_signals(self):
@@ -184,6 +191,8 @@ class UsersView(QWidget):
         self.btnChangePassword.clicked.connect(self.on_change_password_clicked)
         self.btnAddGroup.clicked.connect(self.on_add_group_clicked)
         self.btnRemoveGroup.clicked.connect(self.on_remove_group_clicked)
+        self.buttonBox.rejected.connect(self.close)
+        self.buttonBox.accepted.connect(self.on_save_clicked)
 
     def refresh_lists(self):
         # Preserva seleção e posição de scroll atuais
@@ -478,4 +487,11 @@ class UsersView(QWidget):
                 self, "Erro", f"Falha ao remover o aluno da turma.\nMotivo: {e}"
             )
         self._update_group_lists(username)
+
+    def on_save_clicked(self):
+        if self.controller:
+            try:
+                self.controller.flush()
+            except AttributeError:
+                pass
 


### PR DESCRIPTION
## Summary
- add QDialogButtonBox with Save and Close to UsersView layout
- connect button box to close window and stub save handler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895fe142394832e960a0e815c31b6c4