### PR TITLE
Integrate group management into main window and enhance privilege workflows

### DIFF
--- a/gerenciador_postgres/controllers/groups_controller.py
+++ b/gerenciador_postgres/controllers/groups_controller.py
@@ -34,11 +34,14 @@ class GroupsController(QObject):
             self.data_changed.emit()
         return success
 
+    def list_group_members(self, group_name: str):
+        return self.role_manager.list_group_members(group_name)
+
     # ---------------------------------------------------------------
     # Operações de privilégios
     # ---------------------------------------------------------------
-    def get_schema_tables(self):
-        return self.role_manager.list_tables_by_schema()
+    def get_schema_tables(self, **kwargs):
+        return self.role_manager.list_tables_by_schema(**kwargs)
 
     def list_privilege_templates(self):
         return PERMISSION_TEMPLATES

--- a/gerenciador_postgres/gui/main_window.py
+++ b/gerenciador_postgres/gui/main_window.py
@@ -32,6 +32,7 @@ class MainWindow(QMainWindow):
         self.role_manager = None
         self.users_controller = None
         self.groups_controller = None
+        self.groups_view = None
         self.schema_manager = None
         self.schema_controller = None
         self.audit_manager = None
@@ -117,10 +118,9 @@ class MainWindow(QMainWindow):
         """Abre a janela para gerenciamento de grupos e privilégios."""
         from .groups_view import GroupsView
         if self.groups_controller:
-            grp_window = GroupsView(controller=self.groups_controller)
-            self.opened_windows.append(grp_window)
-            grp_window.setWindowTitle("Gerenciador de Grupos e Privilégios")
-            grp_window.show()
+            if not self.groups_view:
+                self.groups_view = GroupsView(controller=self.groups_controller)
+            self.setCentralWidget(self.groups_view)
         else:
             QMessageBox.warning(
                 self,
@@ -211,6 +211,8 @@ class MainWindow(QMainWindow):
         self.schema_controller = None
         self.audit_manager = None
         self.audit_controller = None
+        self.groups_view = None
+        self.setCentralWidget(self.label)
         self.menuGerenciar.setEnabled(False)
         self.statusbar.showMessage("Não conectado")
         QMessageBox.information(self, "Desconectado", "Conexão encerrada.")

--- a/gerenciador_postgres/role_manager.py
+++ b/gerenciador_postgres/role_manager.py
@@ -367,9 +367,9 @@ class RoleManager:
 
     # Métodos de tabelas e privilégios ------------------------------------
 
-    def list_tables_by_schema(self) -> Dict[str, List[str]]:
+    def list_tables_by_schema(self, **kwargs) -> Dict[str, List[str]]:
         try:
-            return self.dao.list_tables_by_schema()
+            return self.dao.list_tables_by_schema(**kwargs)
         except Exception as e:
             self.logger.error(f"[{self.operador}] Erro ao listar tabelas: {e}")
             return {}


### PR DESCRIPTION
## Summary
- Embed the groups management view directly in the main window and reset on disconnect
- Broaden schema table lookup to include views and allow filtering
- Display group members and perform template/privilege updates asynchronously with progress dialogs

## Testing
- `python -m py_compile gerenciador_postgres/gui/main_window.py gerenciador_postgres/db_manager.py gerenciador_postgres/role_manager.py gerenciador_postgres/controllers/groups_controller.py gerenciador_postgres/gui/groups_view.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895fde71240832ea141270074ceb12f