### PR TITLE
Load group privileges and show empty schemas

### DIFF
--- a/gerenciador_postgres/controllers/groups_controller.py
+++ b/gerenciador_postgres/controllers/groups_controller.py
@@ -43,6 +43,9 @@ class GroupsController(QObject):
     def get_schema_tables(self, **kwargs):
         return self.role_manager.list_tables_by_schema(**kwargs)
 
+    def get_group_privileges(self, group_name: str):
+        return self.role_manager.get_group_privileges(group_name)
+
     def list_privilege_templates(self):
         return PERMISSION_TEMPLATES
 

--- a/gerenciador_postgres/gui/groups_view.py
+++ b/gerenciador_postgres/gui/groups_view.py
@@ -196,6 +196,7 @@ class GroupsView(QWidget):
         if not self.controller or not self.current_group:
             return
         data = self.controller.get_schema_tables()
+        privileges = self.controller.get_group_privileges(self.current_group)
         self.treePrivileges.clear()
         for schema, tables in data.items():
             schema_item = QTreeWidgetItem([schema])
@@ -211,8 +212,10 @@ class GroupsView(QWidget):
                     | Qt.ItemFlag.ItemIsUserCheckable
                     | Qt.ItemFlag.ItemIsSelectable
                 )
-                for col in range(1, 5):
-                    table_item.setCheckState(col, Qt.CheckState.Unchecked)
+                perms = privileges.get(schema, {}).get(table, set())
+                for col, label in enumerate(["SELECT", "INSERT", "UPDATE", "DELETE"], start=1):
+                    state = Qt.CheckState.Checked if label in perms else Qt.CheckState.Unchecked
+                    table_item.setCheckState(col, state)
                 schema_item.addChild(table_item)
         self.treePrivileges.expandAll()
 

--- a/gerenciador_postgres/role_manager.py
+++ b/gerenciador_postgres/role_manager.py
@@ -374,6 +374,15 @@ class RoleManager:
             self.logger.error(f"[{self.operador}] Erro ao listar tabelas: {e}")
             return {}
 
+    def get_group_privileges(self, group_name: str) -> Dict[str, Dict[str, Set[str]]]:
+        try:
+            return self.dao.get_group_privileges(group_name)
+        except Exception as e:
+            self.logger.error(
+                f"[{self.operador}] Erro ao obter privilégios do grupo '{group_name}': {e}"
+            )
+            return {}
+
     def set_group_privileges(self, group_name: str, privileges: Dict[str, Dict[str, Set[str]]]) -> bool:
         try:
             self.dao.apply_group_privileges(group_name, privileges)

--- a/tests/test_db_manager_tables.py
+++ b/tests/test_db_manager_tables.py
@@ -1,0 +1,58 @@
+import unittest
+import pathlib
+import sys
+import unittest
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from gerenciador_postgres.db_manager import DBManager
+
+
+class DummyCursor:
+    def __init__(self, data):
+        self.data = data
+        self.result = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql, params=None):
+        if "information_schema.schemata" in sql:
+            self.result = [(s,) for s in self.data["schemas"]]
+        elif "FROM pg_catalog.pg_class" in sql:
+            self.result = self.data["tables"]
+        else:
+            self.result = []
+
+    def fetchall(self):
+        return self.result
+
+
+class DummyConn:
+    def __init__(self, data):
+        self.data = data
+
+    def cursor(self):
+        return DummyCursor(self.data)
+
+
+class DBManagerTableTests(unittest.TestCase):
+    def setUp(self):
+        data = {
+            "schemas": ["public", "empty_schema"],
+            "tables": [("public", "t1"), ("public", "t2")],
+        }
+        self.dbm = DBManager(DummyConn(data))
+
+    def test_list_tables_by_schema_includes_empty(self):
+        expected = {"public": ["t1", "t2"], "empty_schema": []}
+        self.assertEqual(self.dbm.list_tables_by_schema(), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_role_manager_privileges.py
+++ b/tests/test_role_manager_privileges.py
@@ -1,0 +1,39 @@
+import unittest
+import logging
+import unittest
+import logging
+
+from gerenciador_postgres.role_manager import RoleManager
+
+
+class DummyDAO:
+    def __init__(self, privileges):
+        self.conn = DummyConn()
+        self.privileges = privileges
+
+    def get_group_privileges(self, group):
+        return self.privileges.get(group, {})
+
+
+class DummyConn:
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+
+class RoleManagerPrivilegesTests(unittest.TestCase):
+    def setUp(self):
+        privs = {"grp_a": {"public": {"t1": {"SELECT"}}}}
+        self.dao = DummyDAO(privs)
+        self.rm = RoleManager(self.dao, logging.getLogger("test"))
+
+    def test_get_group_privileges(self):
+        expected = {"public": {"t1": {"SELECT"}}}
+        self.assertEqual(self.rm.get_group_privileges("grp_a"), expected)
+        self.assertEqual(self.rm.get_group_privileges("grp_b"), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Include empty schemas in table listing
- Display existing group privileges in group view
- Add tests for privilege retrieval and schema listing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68965a245f50832eb57c5a4d69245463