### PR TITLE
Refine schema management UX

### DIFF
--- a/gerenciador_postgres/db_manager.py
+++ b/gerenciador_postgres/db_manager.py
@@ -325,7 +325,7 @@ class DBManager:
             cur.execute("""
                 SELECT schema_name
                 FROM information_schema.schemata
-                WHERE schema_name NOT IN ('pg_catalog', 'information_schema')
+                WHERE schema_name NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
                 ORDER BY schema_name
             """)
             return [row[0] for row in cur.fetchall()]

--- a/gerenciador_postgres/gui/main_window.py
+++ b/gerenciador_postgres/gui/main_window.py
@@ -251,9 +251,10 @@ class MainWindow(QMainWindow):
         from .schema_view import SchemaView
         if self.schema_controller:
             schema_window = SchemaView(controller=self.schema_controller, logger=self.logger)
-            self.opened_windows.append(schema_window)
             schema_window.setWindowTitle("Gerenciador de Schemas")
-            schema_window.show()
+            sub_window = self.mdi.addSubWindow(schema_window)
+            self.opened_windows.append(sub_window)
+            sub_window.show()
         else:
             QMessageBox.warning(self, "Não Conectado", "Você precisa estar conectado a um banco de dados para gerenciar schemas.")
     

--- a/gerenciador_postgres/gui/schema_view.py
+++ b/gerenciador_postgres/gui/schema_view.py
@@ -121,7 +121,23 @@ class SchemaView(QWidget):
         if not item:
             return
         name = item.text()
-        new_owner, ok = QInputDialog.getText(self, "Alterar Owner", f"Novo owner para '{name}':")
+        roles = []
+        if self.controller:
+            try:
+                roles = self.controller.list_roles()
+            except Exception as e:
+                if self.logger:
+                    self.logger.error(f"Falha ao listar roles: {e}")
+
+        if roles:
+            new_owner, ok = QInputDialog.getItem(
+                self, "Alterar Owner", "Novo owner:", roles, 0, False
+            )
+        else:
+            new_owner, ok = QInputDialog.getText(
+                self, "Alterar Owner", f"Novo owner para '{name}':"
+            )
+
         if not ok or not new_owner:
             return
         try:


### PR DESCRIPTION
## Summary
- Open schema management window inside the main MDI area
- Hide pg_toast from schema listings
- Allow selecting new schema owners from existing roles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68968db39490832eaa739909a0911de2