### PR TITLE
Fix audit window opening

### DIFF
--- a/gerenciador_postgres/gui/main_window.py
+++ b/gerenciador_postgres/gui/main_window.py
@@ -263,14 +263,15 @@ class MainWindow(QMainWindow):
         from .audit_view import AuditView
         if self.audit_manager and self.audit_controller:
             audit_window = AuditView(
-                audit_manager=self.audit_manager, 
+                audit_manager=self.audit_manager,
                 logger=self.logger
             )
-            self.opened_windows.append(audit_window)
             audit_window.setWindowTitle("Auditoria do Sistema")
-            audit_window.show()
+            sub_window = self.mdi.addSubWindow(audit_window)
+            self.opened_windows.append(sub_window)
+            sub_window.show()
         else:
             QMessageBox.warning(
-                self, "Não Conectado", 
+                self, "Não Conectado",
                 "Você precisa estar conectado a um banco de dados para acessar a auditoria."
             )


### PR DESCRIPTION
## Summary
- Ensure the audit window is added as an MDI subwindow so it displays correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896932926ac832eb46dbcfa9d9c7c5d