### PR TITLE
Normalize user names before creating usernames

### DIFF
--- a/gerenciador_postgres/role_manager.py
+++ b/gerenciador_postgres/role_manager.py
@@ -96,7 +96,9 @@ class RoleManager:
         created: List[str] = []
         for matricula, nome_completo in users_info:
             password = matricula
-            partes = nome_completo.strip().split()
+            nome_normalizado = unicodedata.normalize('NFKD', nome_completo)
+            nome_ascii = nome_normalizado.encode('ascii', 'ignore').decode('ascii')
+            partes = nome_ascii.strip().split()
             if not partes:
                 continue
             first = partes[0].lower()

--- a/tests/test_user_group_management.py
+++ b/tests/test_user_group_management.py
@@ -62,13 +62,13 @@ class UserGroupManagementTests(unittest.TestCase):
 
     def test_create_users_batch(self):
         data = [
-            ("111", "Bob Silva"),
-            ("222", "Carol Dias"),
+            ("111", "José Silva"),
+            ("222", "José Ângelo"),
         ]
         created = self.uc.create_users_batch(data, "2024-06-30")
-        self.assertEqual(set(created), {"bob", "carol"})
-        self.assertEqual(self.dao.users["bob"]["password"], "111")
-        self.assertEqual(self.dao.users["carol"]["valid_until"], "2024-06-30")
+        self.assertEqual(set(created), {"jose", "jose.angelo"})
+        self.assertEqual(self.dao.users["jose"]["password"], "111")
+        self.assertEqual(self.dao.users["jose.angelo"]["valid_until"], "2024-06-30")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Normalize full names with `unicodedata` before generating usernames
- Add test coverage for creating users with accented names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896979e14b0832e894d8b4373123b90