### PR TITLE
Add logging and context manager to ConnectionManager

### DIFF
--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -1,7 +1,9 @@
 import os
 import sys
+import logging
 from unittest.mock import MagicMock
 import pytest
+from psycopg2 import OperationalError
 
 # Ensure project root is on path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -31,3 +33,34 @@ def test_get_connection_inactive():
     cm._conn = mock_conn
     with pytest.raises(ConnectionError):
         cm.get_connection()
+
+
+def test_connect_logs_operational_error(monkeypatch, caplog):
+    cm = ConnectionManager()
+
+    def fake_connect(**kwargs):
+        raise OperationalError("erro")
+
+    monkeypatch.setattr(
+        "gerenciador_postgres.connection_manager.psycopg2.connect",
+        fake_connect,
+    )
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(OperationalError):
+            cm.connect(host="localhost")
+
+    assert "Erro operacional ao conectar ao banco de dados" in caplog.text
+
+
+def test_context_manager_auto_disconnect():
+    cm = ConnectionManager()
+    mock_conn = MagicMock()
+    mock_conn.closed = 0
+    cm._conn = mock_conn
+
+    with cm as conn:
+        assert conn is mock_conn
+
+    mock_conn.close.assert_called_once()
+    assert cm._conn is None


### PR DESCRIPTION
## Summary
- log OperationalError and unexpected exceptions when establishing database connections
- allow ConnectionManager use as a context manager with automatic disconnect
- extend connection manager tests for error logging and context manager behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68969adc5634832eafd8b9ffa13c6cc3