### PR TITLE
feat: make group prefix configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,16 @@ Aplicação em Python com interface gráfica (PyQt6) para facilitar a administra
 2. (Opcional) Crie e ative um ambiente virtual.
 3. Instale as dependências:
    ```bash
-   pip install -r requirements.txt
-   pip install pytest
-   ```
+    pip install -r requirements.txt
+    pip install pytest
+    ```
+
+## Configuração
+O arquivo `config/config.yml` centraliza parâmetros do sistema. Nele é possível definir:
+
+- `log_level`: nível de detalhamento dos logs.
+- `log_path`: caminho do arquivo de log.
+- `group_prefix`: prefixo obrigatório para nomes de grupos (padrão `"grp_"`).
 
 ## Execução
 Para iniciar a interface gráfica do gerenciador, execute:

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,2 +1,3 @@
 log_level: INFO
 log_path: D:\GitHub\IFSC_SGBD\logs\app.log
+group_prefix: "grp_"

--- a/gerenciador_postgres/config_manager.py
+++ b/gerenciador_postgres/config_manager.py
@@ -4,7 +4,8 @@ from .path_config import CONFIG_DIR, BASE_DIR
 CONFIG_FILE = CONFIG_DIR / 'config.yml'
 DEFAULT_CONFIG = {
     'log_path': str(BASE_DIR / 'logs' / 'app.log'),
-    'log_level': 'INFO'
+    'log_level': 'INFO',
+    'group_prefix': 'grp_'
 }
 
 def load_config():

--- a/gerenciador_postgres/role_manager.py
+++ b/gerenciador_postgres/role_manager.py
@@ -4,6 +4,7 @@ from typing import Optional, List, Dict, Set
 import logging
 import unicodedata
 from psycopg2 import sql
+from .config_manager import load_config
 
 class RoleManager:
     """Camada de serviço: orquestra operações, valida regras e controla transações."""
@@ -281,8 +282,10 @@ class RoleManager:
     # Métodos de grupo
     def create_group(self, group_name: str) -> str:
         try:
-            if not group_name.startswith('grp_'):
-                raise ValueError("Nome de grupo deve começar com 'grp_'.")
+            config = load_config()
+            prefix = config.get("group_prefix", "grp_")
+            if not group_name.startswith(prefix):
+                raise ValueError(f"Nome de grupo deve começar com '{prefix}'.")
             if group_name in self.dao.list_groups():
                 raise ValueError(f"Grupo '{group_name}' já existe.")
             self.dao.create_group(group_name)

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -12,3 +12,4 @@ def test_load_config_creates_file(tmp_path, monkeypatch):
     assert config_file.exists()
     assert data["log_level"] == "INFO"
     assert "log_path" in data
+    assert data["group_prefix"] == "grp_"

--- a/tests/test_role_manager_group_prefix.py
+++ b/tests/test_role_manager_group_prefix.py
@@ -1,0 +1,47 @@
+import logging
+import unittest
+from unittest.mock import patch
+
+from gerenciador_postgres.role_manager import RoleManager
+
+
+class DummyDAO:
+    def __init__(self):
+        self.conn = DummyConn()
+        self.groups = set()
+
+    def list_groups(self):
+        return list(self.groups)
+
+    def create_group(self, name):
+        self.groups.add(name)
+
+
+class DummyConn:
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+
+class RoleManagerGroupPrefixTests(unittest.TestCase):
+    def setUp(self):
+        self.dao = DummyDAO()
+        self.rm = RoleManager(self.dao, logging.getLogger("test"))
+
+    def test_create_group_respects_prefix(self):
+        with patch("gerenciador_postgres.role_manager.load_config", return_value={"group_prefix": "grp_"}):
+            created = self.rm.create_group("grp_valid")
+            self.assertEqual(created, "grp_valid")
+            self.assertIn("grp_valid", self.dao.groups)
+
+    def test_create_group_invalid_prefix(self):
+        with patch("gerenciador_postgres.role_manager.load_config", return_value={"group_prefix": "class_"}):
+            with self.assertRaises(ValueError):
+                self.rm.create_group("grp_invalid")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add `group_prefix` setting with default `grp_`
- validate group names against configured prefix
- document configuration and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68969ae7d72c832eba1cecac64b449e9