### PR TITLE
Handle YAML errors when loading config

### DIFF
--- a/gerenciador_postgres/config_manager.py
+++ b/gerenciador_postgres/config_manager.py
@@ -1,3 +1,4 @@
+import logging
 import yaml
 from .path_config import CONFIG_DIR, BASE_DIR
 
@@ -8,6 +9,8 @@ DEFAULT_CONFIG = {
     'group_prefix': 'grp_'
 }
 
+logger = logging.getLogger(__name__)
+
 def load_config():
     if not CONFIG_FILE.exists():
         CONFIG_DIR.mkdir(exist_ok=True)
@@ -15,7 +18,13 @@ def load_config():
             yaml.safe_dump(DEFAULT_CONFIG, f, allow_unicode=True)
         return DEFAULT_CONFIG.copy()
     with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
-        data = yaml.safe_load(f) or {}
+        try:
+            data = yaml.safe_load(f) or {}
+        except yaml.YAMLError as e:
+            logger.warning("Failed to parse %s: %s", CONFIG_FILE, e)
+            with open(CONFIG_FILE, 'w', encoding='utf-8') as fw:
+                yaml.safe_dump(DEFAULT_CONFIG, fw, allow_unicode=True)
+            return DEFAULT_CONFIG.copy()
     return {**DEFAULT_CONFIG, **data}
 
 def save_config(data):

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,3 +1,5 @@
+import logging
+import yaml
 from gerenciador_postgres import config_manager
 
 
@@ -13,3 +15,19 @@ def test_load_config_creates_file(tmp_path, monkeypatch):
     assert data["log_level"] == "INFO"
     assert "log_path" in data
     assert data["group_prefix"] == "grp_"
+
+
+def test_load_config_yaml_error(tmp_path, monkeypatch, caplog):
+    config_dir = tmp_path / "config"
+    config_file = config_dir / "config.yml"
+    config_dir.mkdir()
+    config_file.write_text("log_level: [INFO", encoding="utf-8")
+    monkeypatch.setattr(config_manager, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(config_manager, "CONFIG_FILE", config_file)
+
+    with caplog.at_level(logging.WARNING):
+        data = config_manager.load_config()
+    assert "Failed to parse" in caplog.text
+
+    assert data == config_manager.DEFAULT_CONFIG
+    assert yaml.safe_load(config_file.read_text()) == config_manager.DEFAULT_CONFIG


### PR DESCRIPTION
## Summary
- wrap YAML loading in `try`/`except` to log and recover from malformed `config.yml`
- add regression test for YAML parse errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896a13d4f94832e9febe8c760c24326