### PR TITLE
Add database profiles and connection management

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -1,3 +1,9 @@
 log_level: INFO
 log_path: D:\GitHub\IFSC_SGBD\logs\app.log
 group_prefix: "grp_"
+databases:
+  - name: "local"
+    host: "localhost"
+    dbname: "postgres"
+    user: "postgres"
+    port: 5432

--- a/gerenciador_postgres/connection_manager.py
+++ b/gerenciador_postgres/connection_manager.py
@@ -2,6 +2,7 @@ import logging
 import psycopg2
 from psycopg2.extensions import connection
 from psycopg2 import OperationalError
+from .config_manager import load_config
 
 
 logger = logging.getLogger(__name__)
@@ -15,7 +16,46 @@ class ConnectionManager:
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             cls._instance._conn = None
+            cls._instance._connections = {}
         return cls._instance
+
+    def connect_to(self, profile_name: str) -> connection:
+        """Conecta usando perfil definido em configuração.
+
+        Mantém um dicionário de conexões ativas e reutiliza conexões já
+        estabelecidas para o perfil solicitado.
+        """
+        config = load_config()
+        profiles = {db['name']: db for db in config.get('databases', [])}
+        profile = profiles.get(profile_name)
+        if not profile:
+            raise ValueError(f"Perfil '{profile_name}' não encontrado")
+
+        conn = self._connections.get(profile_name)
+        if conn and getattr(conn, "closed", 1) == 0:
+            self._conn = conn
+            return conn
+
+        params = {
+            'host': profile['host'],
+            'dbname': profile.get('dbname') or profile.get('database'),
+            'user': profile['user'],
+            'port': profile.get('port', 5432)
+        }
+        if 'password' in profile:
+            params['password'] = profile['password']
+
+        try:
+            conn = psycopg2.connect(**params)
+            self._connections[profile_name] = conn
+            self._conn = conn
+        except OperationalError as e:
+            logger.exception("Erro operacional ao conectar ao banco de dados")
+            raise
+        except Exception:
+            logger.exception("Erro inesperado ao conectar ao banco de dados")
+            raise
+        return conn
 
     def connect(self, **params) -> connection:
         """Estabelece uma nova conexão usando os parâmetros fornecidos."""
@@ -37,10 +77,21 @@ class ConnectionManager:
             return self._conn
         raise ConnectionError("Conexão não ativa")
 
-    def disconnect(self):
-        """Encerra a conexão ativa, se existir."""
+    def disconnect(self, profile_name: str | None = None):
+        """Encerra a conexão ativa ou de um perfil específico."""
+        if profile_name:
+            conn = self._connections.pop(profile_name, None)
+            if conn:
+                conn.close()
+                if self._conn is conn:
+                    self._conn = None
+            return
         if self._conn:
             self._conn.close()
+            for name, conn in list(self._connections.items()):
+                if conn is self._conn:
+                    del self._connections[name]
+                    break
             self._conn = None
 
     def __enter__(self) -> connection:

--- a/gerenciador_postgres/gui/connection_dialog.py
+++ b/gerenciador_postgres/gui/connection_dialog.py
@@ -3,313 +3,48 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QLabel,
-    QLineEdit,
     QComboBox,
     QDialogButtonBox,
-    QMessageBox,
-    QInputDialog,
-    QPushButton,
-    QCheckBox,
-    QProgressDialog,
-    QStyle,
 )
-from PyQt6.QtGui import QIcon, QAction
-from PyQt6.QtCore import Qt, QThread, pyqtSignal
+from PyQt6.QtGui import QIcon
 from pathlib import Path
-try:
-    import keyring  # type: ignore
-    KEYRING_AVAILABLE = True
-except ImportError:
-    keyring = None  # type: ignore
-    KEYRING_AVAILABLE = False
-import json
-import os
+from ..config_manager import load_config
 
-PROFILE_FILE = os.path.expanduser('~/.gerenciador_postgres_profiles.json')
-
-
-class ConnectionWorker(QThread):
-    """Worker thread para testar conexão sem bloquear a interface."""
-
-    success = pyqtSignal()
-    error = pyqtSignal(str)
-
-    def __init__(self, params, parent=None):
-        super().__init__(parent)
-        self.params = params
-        self._cancelled = False
-
-    def run(self):
-        try:
-            import psycopg2
-
-            conn = psycopg2.connect(connect_timeout=5, **self.params)
-            conn.close()
-            if not self._cancelled:
-                self.success.emit()
-        except Exception as e:
-            if not self._cancelled:
-                self.error.emit(str(e))
-
-    def cancel(self):
-        self._cancelled = True
-        self.terminate()
 
 class ConnectionDialog(QDialog):
+    """Diálogo simples para seleção de perfil de conexão."""
+
     def __init__(self, parent=None):
         super().__init__(parent)
         assets_dir = Path(__file__).resolve().parents[2] / "assets"
         self.setWindowIcon(QIcon(str(assets_dir / "icone.png")))
         self.setWindowTitle("Conectar ao Banco de Dados")
         self.setModal(True)
-        self.resize(400, 220)
+        self.resize(300, 100)
         self._setup_ui()
         self._load_profiles()
-        self._cancelled_by_user = False
-        if not KEYRING_AVAILABLE:
-            QMessageBox.warning(
-                self,
-                "Keyring não disponível",
-                "O módulo 'keyring' não está instalado. As funções de salvar senha serão desabilitadas.\n"
-                "Instale-o com: pip install keyring",
-            )
-            self.chkSavePassword.setEnabled(False)
 
     def _setup_ui(self):
         layout = QVBoxLayout(self)
 
-        # --- Perfil de Conexão ---
         profile_layout = QHBoxLayout()
         profile_layout.addWidget(QLabel("Perfil de conexão:"))
         self.cmbProfiles = QComboBox()
-        self.cmbProfiles.addItem("Novo perfil...")
-        self.cmbProfiles.currentIndexChanged.connect(self._on_profile_selected)
         profile_layout.addWidget(self.cmbProfiles)
-        self.btnSaveProfile = QPushButton("Salvar")
-        self.btnDeleteProfile = QPushButton("Deletar")
-        self.btnDeleteProfile.setEnabled(False)
-        profile_layout.addWidget(self.btnSaveProfile)
-        profile_layout.addWidget(self.btnDeleteProfile)
         layout.addLayout(profile_layout)
 
-        # --- Campos de Conexão ---
-        form_layout = QVBoxLayout()
-
-        # Host e Porta (agrupados)
-        host_port_layout = QHBoxLayout()
-        self.txtHost = QLineEdit()
-        self.txtPort = QLineEdit()
-        self.txtPort.setText("5432")
-        host_port_layout.addWidget(QLabel("Host:"))
-        host_port_layout.addWidget(self.txtHost)
-        host_port_layout.addWidget(QLabel("Porta:"))
-        host_port_layout.addWidget(self.txtPort, 1)
-        form_layout.addLayout(host_port_layout)
-
-        # Banco
-        db_layout = QHBoxLayout()
-        self.txtDb = QLineEdit()
-        db_layout.addWidget(QLabel("Banco:"))
-        db_layout.addWidget(self.txtDb)
-        form_layout.addLayout(db_layout)
-
-        # Usuário
-        user_layout = QHBoxLayout()
-        self.txtUser = QLineEdit()
-        user_layout.addWidget(QLabel("Usuário:"))
-        user_layout.addWidget(self.txtUser)
-        form_layout.addLayout(user_layout)
-
-        # Senha (com checkbox e botão de visibilidade)
-        password_layout = QHBoxLayout()
-        self.txtPassword = QLineEdit()
-        self.txtPassword.setEchoMode(QLineEdit.EchoMode.Password)
-        password_layout.addWidget(QLabel("Senha:"))
-        password_layout.addWidget(self.txtPassword)
-
-        self.chkSavePassword = QCheckBox("Salvar Senha")
-        self.chkSavePassword.setChecked(True)
-        password_layout.addWidget(self.chkSavePassword)
-
-        # Botão para mostrar/ocultar senha
-        self.toggle_password_action = QAction(QIcon(), "Mostrar/Ocultar Senha", self)
-        self.toggle_password_action.setCheckable(True)
-        self.toggle_password_action.triggered.connect(self.toggle_password_visibility)
-        self.txtPassword.addAction(self.toggle_password_action, QLineEdit.ActionPosition.TrailingPosition)
-        self.toggle_password_action.setIcon(
-            self.style().standardIcon(QStyle.StandardPixmap.SP_DialogApplyButton)
+        self.buttonBox = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
         )
-
-        form_layout.addLayout(password_layout)
-        layout.addLayout(form_layout)
-
-        # --- Botões OK e Cancelar ---
-        self.buttonBox = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
         self.buttonBox.accepted.connect(self.accept)
         self.buttonBox.rejected.connect(self.reject)
         layout.addWidget(self.buttonBox)
 
-        # Conectar sinais dos botões de gerenciamento
-        self.btnSaveProfile.clicked.connect(self.on_save_profile)
-        self.btnDeleteProfile.clicked.connect(self.on_delete_profile)
-
-    def toggle_password_visibility(self, checked):
-        if checked:
-            self.txtPassword.setEchoMode(QLineEdit.EchoMode.Normal)
-        else:
-            self.txtPassword.setEchoMode(QLineEdit.EchoMode.Password)
-
     def _load_profiles(self):
-        self.profiles = {}
-        if os.path.exists(PROFILE_FILE):
-            try:
-                with open(PROFILE_FILE, 'r', encoding='utf-8') as f:
-                    self.profiles = json.load(f)
-                for name in self.profiles:
-                    self.cmbProfiles.addItem(name)
-            except Exception:
-                pass
+        config = load_config()
+        self.profiles = {db['name']: db for db in config.get('databases', [])}
+        self.cmbProfiles.addItems(self.profiles.keys())
 
-    def _on_profile_selected(self, idx):
-        self.btnDeleteProfile.setEnabled(idx > 0)
-        if idx == 0:
-            self.txtHost.clear()
-            self.txtDb.clear()
-            self.txtUser.clear()
-            self.txtPassword.clear()
-            self.txtPort.setText("5432")
-            self.chkSavePassword.setChecked(True if KEYRING_AVAILABLE else False)
-        else:
-            name = self.cmbProfiles.currentText()
-            prof = self.profiles.get(name, {})
-            self.txtHost.setText(prof.get('host', ''))
-            self.txtDb.setText(prof.get('database', ''))
-            self.txtUser.setText(prof.get('user', ''))
-            self.txtPort.setText(str(prof.get('port', '5432')))
-            if KEYRING_AVAILABLE:
-                self.txtPassword.setText(keyring.get_password('gerenciador_postgres', name) or '')
-                # Verifica se existe uma senha salva e atualiza a checkbox
-                password_exists = bool(keyring.get_password('gerenciador_postgres', name))
-                self.chkSavePassword.setChecked(password_exists)
-            else:
-                self.txtPassword.clear()
-                self.chkSavePassword.setChecked(False)
-
-    def get_params(self):
-        return {
-            'host': self.txtHost.text().strip(),
-            'database': self.txtDb.text().strip(),
-            'user': self.txtUser.text().strip(),
-            'password': self.txtPassword.text(),
-            'port': int(self.txtPort.text().strip() or 5432)
-        }
-
-    def save_profile(self, name):
-        prof = self.get_params().copy()
-        password_text = prof.pop('password')  # Pega a senha dos campos
-        self.profiles[name] = prof
-
-        # Salva o perfil no arquivo JSON
-        with open(PROFILE_FILE, 'w', encoding='utf-8') as f:
-            json.dump(self.profiles, f, ensure_ascii=False, indent=2)
-
-        # Decide se salva ou apaga a senha do keyring
-        if KEYRING_AVAILABLE and self.chkSavePassword.isChecked():
-            keyring.set_password('gerenciador_postgres', name, password_text)
-        elif KEYRING_AVAILABLE:
-            try:
-                # Garante que qualquer senha antiga seja removida se a caixa estiver desmarcada
-                keyring.delete_password('gerenciador_postgres', name)
-            except (AttributeError, Exception):
-                # Ignora erros se a senha não existir ou o keyring não estiver disponível
-                pass
-
-    def accept(self):
-        params = self.get_params()
-        if not all([params['host'], params['database'], params['user'], params['password']] ):
-            QMessageBox.warning(self, "Campos obrigatórios", "Preencha todos os campos obrigatórios.")
-            return
-
-        self._cancelled_by_user = False
-        self.progress_dialog = QProgressDialog("Conectando…", "Cancelar", 0, 0, self)
-        self.progress_dialog.setWindowModality(Qt.WindowModality.WindowModal)
-        self.progress_dialog.canceled.connect(self._on_cancel_connection)
-        self.progress_dialog.show()
-
-        self.worker = ConnectionWorker(params, self)
-        self.worker.success.connect(self._on_connection_success)
-        self.worker.error.connect(self._on_connection_error)
-        self.worker.start()
-
-    def _on_connection_success(self):
-        self.progress_dialog.canceled.disconnect(self._on_cancel_connection)
-        self.progress_dialog.close()
-        super().accept()
-
-    def _on_connection_error(self, message):
-        self.progress_dialog.canceled.disconnect(self._on_cancel_connection)
-        self.progress_dialog.close()
-        suggestions = []
-        lower_msg = message.lower()
-        if "could not translate host name" in lower_msg:
-            suggestions.append("Verifique se o host está correto.")
-        if "connection refused" in lower_msg or "timeout" in lower_msg or "could not connect to server" in lower_msg:
-            suggestions.append("Confirme se o servidor está acessível e se a porta está correta.")
-        if "authentication failed" in lower_msg or "password authentication failed" in lower_msg:
-            suggestions.append("Revise usuário e senha informados.")
-
-        if suggestions:
-            message = f"{message}\n\nPossíveis correções:\n- " + "\n- ".join(suggestions)
-
-        QMessageBox.critical(self, "Erro de conexão", f"Não foi possível conectar: {message}")
-
-    def _on_cancel_connection(self):
-        if hasattr(self, 'worker') and self.worker.isRunning():
-            self._cancelled_by_user = True
-            self.worker.cancel()
-        self.progress_dialog.close()
-        if self._cancelled_by_user:
-            QMessageBox.warning(self, "Cancelado", "Conexão cancelada.")
-
-    def on_save_profile(self):
-        # Pergunta o nome do perfil
-        profile_name, ok = QInputDialog.getText(self, "Salvar Perfil", "Digite o nome para o perfil:")
-        if ok and profile_name:
-            try:
-                self.save_profile(profile_name)
-                # Adiciona o novo perfil à combobox se não existir
-                if self.cmbProfiles.findText(profile_name) == -1:
-                    self.cmbProfiles.addItem(profile_name)
-                self.cmbProfiles.setCurrentText(profile_name)
-                QMessageBox.information(self, "Sucesso", f"Perfil '{profile_name}' salvo com sucesso.")
-            except Exception as e:
-                QMessageBox.critical(self, "Erro ao Salvar", f"Não foi possível salvar o perfil: {e}")
-
-    def on_delete_profile(self):
-        profile_name = self.cmbProfiles.currentText()
-        if not profile_name or self.cmbProfiles.currentIndex() == 0:
-            return
-
-        reply = QMessageBox.question(self, "Confirmar Deleção",
-                                     f"Tem certeza que deseja deletar o perfil '{profile_name}'?",
-                                     QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                                     QMessageBox.StandardButton.No)
-
-        if reply == QMessageBox.StandardButton.Yes:
-            try:
-                # Remove do dicionário, do arquivo e do keyring
-                if profile_name in self.profiles:
-                    del self.profiles[profile_name]
-                    with open(PROFILE_FILE, 'w', encoding='utf-8') as f:
-                        json.dump(self.profiles, f, ensure_ascii=False, indent=2)
-                    if KEYRING_AVAILABLE:
-                        keyring.delete_password('gerenciador_postgres', profile_name)
-
-                # Remove da combobox
-                idx = self.cmbProfiles.findText(profile_name)
-                if idx > 0:
-                    self.cmbProfiles.removeItem(idx)
-
-                QMessageBox.information(self, "Sucesso", f"Perfil '{profile_name}' deletado.")
-            except Exception as e:
-                QMessageBox.critical(self, "Erro ao Deletar", f"Não foi possível deletar o perfil: {e}")
+    def get_profile(self) -> str:
+        """Retorna o nome do perfil selecionado."""
+        return self.cmbProfiles.currentText()


### PR DESCRIPTION
## Summary
- add `databases` profiles to configuration
- manage multiple connections via `connect_to`
- simplify connection dialog and hook profile selection into main window

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896b151ed1c832eab78eed520d0d521