### PR TITLE
Add user group transfer with auditing and GUI support

### DIFF
--- a/gerenciador_postgres/controllers/users_controller.py
+++ b/gerenciador_postgres/controllers/users_controller.py
@@ -73,6 +73,12 @@ class UsersController(QObject):
             self.data_changed.emit()
         return success
 
+    def transfer_user_group(self, username: str, old_group: str, new_group: str) -> bool:
+        success = self.role_manager.transfer_user_group(username, old_group, new_group)
+        if success:
+            self.data_changed.emit()
+        return success
+
     # --------------------------------------------------------------
     # Compat: algumas views podem chamar flush(); aqui não há buffer,
     # as operações já comitam imediatamente. Mantemos no-op.

--- a/tests/test_user_group_management.py
+++ b/tests/test_user_group_management.py
@@ -70,6 +70,11 @@ class UserGroupManagementTests(unittest.TestCase):
         self.assertTrue(self.uc.remove_user_from_group("alice", "grp_a"))
         self.assertEqual(self.uc.list_user_groups("alice"), [])
 
+    def test_transfer_group(self):
+        self.uc.add_user_to_group("alice", "grp_a")
+        self.assertTrue(self.uc.transfer_user_group("alice", "grp_a", "grp_b"))
+        self.assertEqual(self.uc.list_user_groups("alice"), ["grp_b"])
+
     def test_create_user_with_expiration(self):
         self.uc.create_user('alice', 'pw', '2025-12-31')
         self.assertEqual(self.dao.users['alice']['valid_until'], '2025-12-31')


### PR DESCRIPTION
## Summary
- support transferring a user between groups in one transaction and audit the operation
- allow selecting students and transferring between groups in the GUI
- expose transfer_user_group in UsersController and add unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896b1b84370832e9550f8c7a96e5b24