### PR TITLE
Add user validity renewal and batch update options

### DIFF
--- a/gerenciador_postgres/controllers/users_controller.py
+++ b/gerenciador_postgres/controllers/users_controller.py
@@ -25,7 +25,11 @@ class UsersController(QObject):
         return self.role_manager.get_user(username)
 
     def create_users_batch(
-        self, users_data: list, valid_until: str | None = None, group_name: str | None = None
+        self,
+        users_data: list,
+        valid_until: str | None = None,
+        group_name: str | None = None,
+        renew: bool = False,
     ):
         """Cria múltiplos usuários de uma vez.
 
@@ -39,9 +43,17 @@ class UsersController(QObject):
             Turma à qual os usuários serão adicionados ou ``None``.
         """
 
-        results = self.role_manager.create_users_batch(users_data, valid_until, group_name)
+        results = self.role_manager.create_users_batch(
+            users_data, valid_until, group_name, renew
+        )
         self.data_changed.emit()
         return results
+
+    def renew_user_validity(self, username: str, new_date: str) -> bool:
+        success = self.role_manager.renew_user_validity(username, new_date)
+        if success:
+            self.data_changed.emit()
+        return success
 
     def delete_user(self, username: str) -> bool:
         success = self.role_manager.delete_user(username)


### PR DESCRIPTION
## Summary
- add `renew_user_validity` helper for user validity renewal
- extend batch creation to optionally renew existing users
- expose renewal in controller and GUI with date picker and button
- test renewal logic and batch renewal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896b592de00832eb0cd7c5f5c639455