### PR TITLE
feat: add hierarchical privilege management

### DIFF
--- a/config/permission_templates.py
+++ b/config/permission_templates.py
@@ -1,9 +1,23 @@
 """Central permission template definitions."""
 
-# Mapping template name to set of privileges
+# Mapping template name to hierarchical privileges
+# Structure:
+# {
+#   'database': {'db_name' or '*': [privileges]},
+#   'schemas': {'schema_name': [privileges]},
+#   'tables': {'schema_name' or '*': [privileges] or {'table': [privileges]}}
+# }
 PERMISSION_TEMPLATES = {
-    "Leitor": {"SELECT"},
-    "Editor": {"SELECT", "INSERT", "UPDATE", "DELETE"},
+    "Leitor": {
+        "database": {"*": ["CONNECT"]},
+        "schemas": {"public": ["USAGE"]},
+        "tables": {"*": ["SELECT"]},
+    },
+    "Editor": {
+        "database": {"*": ["CONNECT"]},
+        "schemas": {"public": ["USAGE", "CREATE"]},
+        "tables": {"*": ["SELECT", "INSERT", "UPDATE", "DELETE"]},
+    },
 }
 
 # Default template applied when creating new groups/turmas

--- a/gerenciador_postgres/controllers/groups_controller.py
+++ b/gerenciador_postgres/controllers/groups_controller.py
@@ -60,3 +60,18 @@ class GroupsController(QObject):
         if success:
             self.data_changed.emit()
         return success
+
+    def grant_database_privileges(self, group_name: str, privileges):
+        success = self.role_manager.grant_database_privileges(group_name, privileges)
+        if success:
+            self.data_changed.emit()
+        return success
+
+    def grant_schema_privileges(self, group_name: str, schema: str, privileges):
+        success = self.role_manager.grant_schema_privileges(group_name, schema, privileges)
+        if success:
+            self.data_changed.emit()
+        return success
+
+    def get_current_database(self):
+        return self.role_manager.dao.conn.get_dsn_parameters().get("dbname")

--- a/gerenciador_postgres/role_manager.py
+++ b/gerenciador_postgres/role_manager.py
@@ -427,22 +427,81 @@ class RoleManager:
             )
             return False
 
+    def grant_database_privileges(self, group_name: str, privileges: Set[str]) -> bool:
+        try:
+            with self.dao.transaction():
+                self.dao.grant_database_privileges(group_name, privileges)
+            self.logger.info(
+                f"[{self.operador}] Atualizou privilégios de banco do grupo '{group_name}'"
+            )
+            return True
+        except Exception as e:
+            self.logger.error(
+                f"[{self.operador}] Falha ao atualizar privilégios de banco do grupo '{group_name}': {e}"
+            )
+            return False
+
+    def grant_schema_privileges(self, group_name: str, schema: str, privileges: Set[str]) -> bool:
+        try:
+            with self.dao.transaction():
+                self.dao.grant_schema_privileges(group_name, schema, privileges)
+            self.logger.info(
+                f"[{self.operador}] Atualizou privilégios do schema '{schema}' para o grupo '{group_name}'"
+            )
+            return True
+        except Exception as e:
+            self.logger.error(
+                f"[{self.operador}] Falha ao atualizar privilégios do schema '{schema}' para o grupo '{group_name}': {e}"
+            )
+            return False
+
     def apply_template_to_group(self, group_name: str, template: str) -> bool:
-        """Aplica um template de permissões a todas as tabelas para o grupo."""
+        """Aplica um template hierárquico de permissões (banco/schema/tabelas)."""
         try:
             from config.permission_templates import PERMISSION_TEMPLATES
 
-            perms = PERMISSION_TEMPLATES.get(template)
-            if perms is None:
+            tpl = PERMISSION_TEMPLATES.get(template)
+            if tpl is None:
                 raise ValueError(f"Template '{template}' não encontrado.")
 
-            tables = self.list_tables_by_schema()
-            privileges: Dict[str, Dict[str, Set[str]]] = {}
-            for schema, tbls in tables.items():
-                for table in tbls:
-                    privileges.setdefault(schema, {})[table] = set(perms)
+            db_perms = tpl.get("database", {})
+            schema_perms = tpl.get("schemas", {})
+            table_perms = tpl.get("tables", {})
 
-            return self.set_group_privileges(group_name, privileges)
+            with self.dao.transaction():
+                dbname = self.dao.conn.get_dsn_parameters().get("dbname")
+                if "*" in db_perms:
+                    self.dao.grant_database_privileges(group_name, set(db_perms["*"]))
+                elif dbname in db_perms:
+                    self.dao.grant_database_privileges(group_name, set(db_perms[dbname]))
+
+                for schema, perms in schema_perms.items():
+                    self.dao.grant_schema_privileges(group_name, schema, set(perms))
+
+                if table_perms:
+                    tables = self.list_tables_by_schema()
+                    privileges: Dict[str, Dict[str, Set[str]]] = {}
+                    for schema, tbls in tables.items():
+                        if schema in table_perms:
+                            schema_def = table_perms[schema]
+                            if isinstance(schema_def, dict):
+                                for tbl, perms in schema_def.items():
+                                    privileges.setdefault(schema, {})[tbl] = set(perms)
+                            else:
+                                perms_set = set(schema_def)
+                                for tbl in tbls:
+                                    privileges.setdefault(schema, {})[tbl] = perms_set
+                        elif "*" in table_perms:
+                            perms_set = set(table_perms["*"])
+                            for tbl in tbls:
+                                privileges.setdefault(schema, {})[tbl] = perms_set
+                    if privileges:
+                        self.dao.apply_group_privileges(group_name, privileges)
+
+            self.logger.info(
+                f"[{self.operador}] Aplicou template '{template}' ao grupo '{group_name}'"
+            )
+            return True
         except Exception as e:
             self.logger.error(
                 f"[{self.operador}] Falha ao aplicar template '{template}' ao grupo '{group_name}': {e}"


### PR DESCRIPTION
## Summary
- add database and schema privilege grant methods
- support hierarchical permission templates with DB and schema levels
- extend privileges view to edit database, schema, and table rights

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896b5a77248832e96efb75ef685a764