### PR TITLE
feat: enforce privilege whitelists and sequence grants

### DIFF
--- a/config/permission_templates.py
+++ b/config/permission_templates.py
@@ -18,10 +18,29 @@ PERMISSION_TEMPLATES = {
     "Editor": {
         "database": {"*": ["CONNECT"]},
         "schemas": {"public": ["USAGE", "CREATE"]},
-        "tables": {"*": ["SELECT", "INSERT", "UPDATE", "DELETE"]},
+        "tables": {
+            "*": [
+                "SELECT",
+                "INSERT",
+                "UPDATE",
+                "DELETE",
+                "TRUNCATE",
+                "REFERENCES",
+                "TRIGGER",
+            ]
+        },
+        "sequences": {"*": ["USAGE", "SELECT", "UPDATE"]},
         "future": {
             "public": {
-                "tables": ["SELECT", "INSERT", "UPDATE", "DELETE"],
+                "tables": [
+                    "SELECT",
+                    "INSERT",
+                    "UPDATE",
+                    "DELETE",
+                    "TRUNCATE",
+                    "REFERENCES",
+                    "TRIGGER",
+                ],
                 "sequences": ["USAGE", "SELECT", "UPDATE"],
                 "functions": ["EXECUTE"],
                 "types": ["USAGE"],

--- a/gerenciador_postgres/controllers/groups_controller.py
+++ b/gerenciador_postgres/controllers/groups_controller.py
@@ -49,8 +49,8 @@ class GroupsController(QObject):
     def list_privilege_templates(self):
         return PERMISSION_TEMPLATES
 
-    def apply_group_privileges(self, group_name: str, privileges):
-        success = self.role_manager.set_group_privileges(group_name, privileges)
+    def apply_group_privileges(self, group_name: str, privileges, obj_type: str = "TABLE"):
+        success = self.role_manager.set_group_privileges(group_name, privileges, obj_type=obj_type)
         if success:
             self.data_changed.emit()
         return success

--- a/tests/test_privilege_whitelist.py
+++ b/tests/test_privilege_whitelist.py
@@ -1,0 +1,32 @@
+import unittest
+
+from gerenciador_postgres.db_manager import DBManager
+
+
+class DummyCursor:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql, params=None):
+        pass
+
+
+class DummyConn:
+    def cursor(self):
+        return DummyCursor()
+
+
+class PrivilegeWhitelistTests(unittest.TestCase):
+    def setUp(self):
+        self.dbm = DBManager(DummyConn())
+
+    def test_invalid_table_privilege(self):
+        with self.assertRaises(ValueError):
+            self.dbm.apply_group_privileges("grp", {"public": {"t1": {"SELECT", "BAD"}}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_role_manager_templates.py
+++ b/tests/test_role_manager_templates.py
@@ -1,6 +1,5 @@
 import logging
 import unittest
-import logging
 from contextlib import contextmanager
 
 from gerenciador_postgres.role_manager import RoleManager
@@ -13,11 +12,11 @@ class DummyDAO:
         self.applied = None
         self.default_privs = []
 
-    def list_tables_by_schema(self):
+    def list_tables_by_schema(self, **kwargs):
         return {"public": ["t1", "t2"]}
 
-    def apply_group_privileges(self, group, privileges):
-        self.applied = (group, privileges)
+    def apply_group_privileges(self, group, privileges, obj_type="TABLE"):
+        self.applied = (group, privileges, obj_type)
 
     def grant_database_privileges(self, group, privileges):
         self.db_privs = (group, privileges)
@@ -64,10 +63,11 @@ class RoleManagerTemplateTests(unittest.TestCase):
         perms = set(PERMISSION_TEMPLATES[template]["tables"]["*"])
         result = self.rm.apply_template_to_group("grp_demo", template)
         self.assertTrue(result)
-        group, privileges = self.dao.applied
+        group, privileges, obj_type = self.dao.applied
         expected = {"public": {"t1": perms, "t2": perms}}
         self.assertEqual(group, "grp_demo")
         self.assertEqual(privileges, expected)
+        self.assertEqual(obj_type, "TABLE")
         # Default privileges
         fut = PERMISSION_TEMPLATES[template]["future"]["public"]["tables"]
         self.assertIn(("grp_demo", "public", "tables", set(fut)), self.dao.default_privs)


### PR DESCRIPTION
## Summary
- allow templates to grant TRUNCATE, REFERENCES, TRIGGER on tables and manage sequence privileges
- validate database, schema, table, sequence privileges against whitelists
- add unit test covering invalid privilege rejection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897ec9997bc832e8be9d3793c30e61f