### PR TITLE
Use relative log path and document config overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,15 @@ Aplicação em Python com interface gráfica (PyQt6) para facilitar a administra
 O arquivo `config/config.yml` centraliza parâmetros do sistema. Nele é possível definir:
 
 - `log_level`: nível de detalhamento dos logs.
-- `log_path`: caminho do arquivo de log.
+- `log_path`: caminho do arquivo de log (relativo a `BASE_DIR`).
 - `group_prefix`: prefixo obrigatório para nomes de grupos (padrão `"grp_"`).
 - `schema_creation_group`: nome do grupo autorizado a criar schemas (padrão `"Professores"`).
 
 Para permitir que outro grupo crie schemas, edite o valor de `schema_creation_group` em `config/config.yml` e reinicie a aplicação.
+
+O caminho informado em `log_path` é convertido para absoluto a partir de `BASE_DIR`, permitindo o uso de caminhos relativos.
+
+Para sobrepor completamente as configurações, defina a variável de ambiente `IFSC_SGBD_CONFIG_FILE` apontando para um arquivo YAML alternativo ou edite o arquivo `config/config.yml` local.
 
 Senhas de banco de dados **não** devem ser armazenadas no arquivo de configuração. 
 O `ConnectionManager` buscará a senha a partir da variável de ambiente 

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,5 @@
 log_level: INFO
-log_path: D:\GitHub\IFSC_SGBD\logs\app.log
+log_path: logs/app.log
 group_prefix: "grp_"
 schema_creation_group: "Professores"
 databases:

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,15 +1,22 @@
 import logging
 import yaml
-from gerenciador_postgres import config_manager
+import importlib
+
+
+def load_module():
+    import gerenciador_postgres.config_manager as cm
+    importlib.reload(cm)
+    return cm
 
 
 def test_load_config_creates_file(tmp_path, monkeypatch):
+    cm = load_module()
     config_dir = tmp_path / "config"
     config_file = config_dir / "config.yml"
-    monkeypatch.setattr(config_manager, "CONFIG_DIR", config_dir)
-    monkeypatch.setattr(config_manager, "CONFIG_FILE", config_file)
+    monkeypatch.setattr(cm, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(cm, "CONFIG_FILE", config_file)
 
-    data = config_manager.load_config()
+    data = cm.load_config()
 
     assert config_file.exists()
     assert data["log_level"] == "INFO"
@@ -19,16 +26,41 @@ def test_load_config_creates_file(tmp_path, monkeypatch):
 
 
 def test_load_config_yaml_error(tmp_path, monkeypatch, caplog):
+    cm = load_module()
     config_dir = tmp_path / "config"
     config_file = config_dir / "config.yml"
     config_dir.mkdir()
     config_file.write_text("log_level: [INFO", encoding="utf-8")
-    monkeypatch.setattr(config_manager, "CONFIG_DIR", config_dir)
-    monkeypatch.setattr(config_manager, "CONFIG_FILE", config_file)
+    monkeypatch.setattr(cm, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(cm, "CONFIG_FILE", config_file)
 
     with caplog.at_level(logging.WARNING):
-        data = config_manager.load_config()
+        data = cm.load_config()
     assert "Failed to parse" in caplog.text
 
-    assert data == config_manager.DEFAULT_CONFIG
-    assert yaml.safe_load(config_file.read_text()) == config_manager.DEFAULT_CONFIG
+    assert data == cm.DEFAULT_CONFIG
+    assert yaml.safe_load(config_file.read_text()) == cm.DEFAULT_CONFIG
+
+
+def test_env_config_file_override(tmp_path, monkeypatch):
+    env_file = tmp_path / "custom.yml"
+    env_file.write_text("log_level: DEBUG\n", encoding="utf-8")
+    monkeypatch.setenv("IFSC_SGBD_CONFIG_FILE", str(env_file))
+    cm = load_module()
+    data = cm.load_config()
+    assert data["log_level"] == "DEBUG"
+
+
+def test_relative_log_path_resolved(tmp_path, monkeypatch):
+    cm = load_module()
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    config_file = config_dir / "config.yml"
+    config_file.write_text("log_path: logs/test.log\n", encoding="utf-8")
+    monkeypatch.setattr(cm, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(cm, "CONFIG_FILE", config_file)
+
+    data = cm.load_config()
+    expected = cm.BASE_DIR / "logs" / "test.log"
+    assert data["log_path"] == str(expected)
+


### PR DESCRIPTION
## Summary
- make default config use a log path relative to BASE_DIR
- support overriding the config file via `IFSC_SGBD_CONFIG_FILE`
- document relative paths and configuration overrides in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898ad84670c832eaca36d12aacc8821