### PR TITLE
feat: add database profiles to config

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -7,4 +7,11 @@ databases:
     host: "localhost"
     dbname: "postgres"
     user: "postgres"
+    password: "postgres"
+    port: 5432
+  - name: "remoto"
+    host: "db.example.com"
+    dbname: "producao"
+    user: "admin"
+    password: "s3cr3t"
     port: 5432


### PR DESCRIPTION
## Summary
- add password for local DB profile
- add remote DB profile with connection info

## Testing
- `pytest` *(fails: OperationalError: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689925237754832eb4b6b0ebc6cf7485