### PR TITLE
Restore single connection dialog with profile load/save and password toggle

### DIFF
--- a/gerenciador_postgres/gui/connection_dialog.py
+++ b/gerenciador_postgres/gui/connection_dialog.py
@@ -3,16 +3,21 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QLabel,
+    QLineEdit,
     QComboBox,
+    QPushButton,
     QDialogButtonBox,
+    QSpinBox,
+    QCheckBox,
+    QMessageBox,
 )
 from PyQt6.QtGui import QIcon
 from pathlib import Path
-from ..config_manager import load_config
+from ..config_manager import load_config, save_config
 
 
 class ConnectionDialog(QDialog):
-    """Diálogo simples para seleção de perfil de conexão."""
+    """Diálogo para entrada e gerenciamento de parâmetros de conexão."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -20,7 +25,8 @@ class ConnectionDialog(QDialog):
         self.setWindowIcon(QIcon(str(assets_dir / "icone.png")))
         self.setWindowTitle("Conectar ao Banco de Dados")
         self.setModal(True)
-        self.resize(300, 100)
+        self.resize(400, 200)
+        self.profiles = {}
         self._setup_ui()
         self._load_profiles()
 
@@ -28,23 +34,127 @@ class ConnectionDialog(QDialog):
         layout = QVBoxLayout(self)
 
         profile_layout = QHBoxLayout()
-        profile_layout.addWidget(QLabel("Perfil de conexão:"))
+        profile_layout.addWidget(QLabel("Perfil:"))
         self.cmbProfiles = QComboBox()
+        self.cmbProfiles.setEditable(True)
         profile_layout.addWidget(self.cmbProfiles)
+        self.btnLoad = QPushButton("Carregar")
+        profile_layout.addWidget(self.btnLoad)
+        self.btnSave = QPushButton("Salvar")
+        profile_layout.addWidget(self.btnSave)
         layout.addLayout(profile_layout)
+
+        # Campos de conexão
+        host_layout = QHBoxLayout()
+        host_layout.addWidget(QLabel("Host:"))
+        self.txtHost = QLineEdit()
+        host_layout.addWidget(self.txtHost)
+        layout.addLayout(host_layout)
+
+        db_layout = QHBoxLayout()
+        db_layout.addWidget(QLabel("Banco:"))
+        self.txtDb = QLineEdit()
+        db_layout.addWidget(self.txtDb)
+        layout.addLayout(db_layout)
+
+        user_layout = QHBoxLayout()
+        user_layout.addWidget(QLabel("Usuário:"))
+        self.txtUser = QLineEdit()
+        user_layout.addWidget(self.txtUser)
+        layout.addLayout(user_layout)
+
+        pwd_layout = QHBoxLayout()
+        pwd_layout.addWidget(QLabel("Senha:"))
+        self.txtPassword = QLineEdit()
+        self.txtPassword.setEchoMode(QLineEdit.EchoMode.Password)
+        pwd_layout.addWidget(self.txtPassword)
+        self.btnTogglePassword = QPushButton("Mostrar")
+        pwd_layout.addWidget(self.btnTogglePassword)
+        layout.addLayout(pwd_layout)
+
+        port_layout = QHBoxLayout()
+        port_layout.addWidget(QLabel("Porta:"))
+        self.spnPort = QSpinBox()
+        self.spnPort.setRange(1, 65535)
+        self.spnPort.setValue(5432)
+        port_layout.addWidget(self.spnPort)
+        layout.addLayout(port_layout)
+
+        self.chkSavePassword = QCheckBox("Salvar senha")
+        layout.addWidget(self.chkSavePassword)
 
         self.buttonBox = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
         )
+        layout.addWidget(self.buttonBox)
+
+        # Conectar sinais
         self.buttonBox.accepted.connect(self.accept)
         self.buttonBox.rejected.connect(self.reject)
-        layout.addWidget(self.buttonBox)
+        self.btnLoad.clicked.connect(self.load_selected_profile)
+        self.btnSave.clicked.connect(self.save_current_profile)
+        self.btnTogglePassword.clicked.connect(self.toggle_password_visibility)
 
     def _load_profiles(self):
         config = load_config()
-        self.profiles = {db['name']: db for db in config.get('databases', [])}
+        self.profiles = {db["name"]: db for db in config.get("databases", [])}
+        self.cmbProfiles.clear()
         self.cmbProfiles.addItems(self.profiles.keys())
 
-    def get_profile(self) -> str:
-        """Retorna o nome do perfil selecionado."""
-        return self.cmbProfiles.currentText()
+    def load_selected_profile(self):
+        name = self.cmbProfiles.currentText()
+        profile = self.profiles.get(name)
+        if not profile:
+            QMessageBox.warning(self, "Perfil não encontrado", f"Perfil '{name}' não existe.")
+            return
+        self.txtHost.setText(profile.get("host", ""))
+        self.txtDb.setText(profile.get("dbname", ""))
+        self.txtUser.setText(profile.get("user", ""))
+        self.spnPort.setValue(profile.get("port", 5432))
+        self.txtPassword.setText(profile.get("password", ""))
+
+    def save_current_profile(self):
+        name = self.cmbProfiles.currentText().strip()
+        if not name:
+            QMessageBox.warning(self, "Nome inválido", "Informe um nome de perfil.")
+            return
+        profile = {
+            "name": name,
+            "host": self.txtHost.text(),
+            "dbname": self.txtDb.text(),
+            "user": self.txtUser.text(),
+            "port": self.spnPort.value(),
+        }
+        if self.chkSavePassword.isChecked() and self.txtPassword.text():
+            profile["password"] = self.txtPassword.text()
+        config = load_config()
+        databases = config.get("databases", [])
+        for i, db in enumerate(databases):
+            if db["name"] == name:
+                databases[i] = profile
+                break
+        else:
+            databases.append(profile)
+        config["databases"] = databases
+        save_config(config)
+        self._load_profiles()
+        QMessageBox.information(self, "Perfil salvo", f"Perfil '{name}' salvo com sucesso.")
+
+    def toggle_password_visibility(self):
+        if self.txtPassword.echoMode() == QLineEdit.EchoMode.Password:
+            self.txtPassword.setEchoMode(QLineEdit.EchoMode.Normal)
+            self.btnTogglePassword.setText("Ocultar")
+        else:
+            self.txtPassword.setEchoMode(QLineEdit.EchoMode.Password)
+            self.btnTogglePassword.setText("Mostrar")
+
+    def get_connection_params(self) -> dict:
+        params = {
+            "host": self.txtHost.text(),
+            "dbname": self.txtDb.text(),
+            "user": self.txtUser.text(),
+            "port": self.spnPort.value(),
+        }
+        if self.txtPassword.text():
+            params["password"] = self.txtPassword.text()
+        return params


### PR DESCRIPTION
## Summary
- Add editable connection dialog with fields for host, database, user, password, and port
- Enable loading and saving connection profiles with optional password storage and visibility toggle
- Adapt main window connection logic to use parameters returned from dialog

## Testing
- `pytest` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6899227a2d38832e88a7ab38c59afbd1