### PR TITLE
Improve error handling in ConnectionManager.connect

### DIFF
--- a/gerenciador_postgres/connection_manager.py
+++ b/gerenciador_postgres/connection_manager.py
@@ -116,12 +116,24 @@ class ConnectionManager:
         """
 
         timeout = int(params.pop("connect_timeout", 5) or 5)
-        logger.info("Conectando ao PostgreSQL em %s:%s/%s (timeout=%ss)...",
-                    params.get("host"), params.get("port"), params.get("dbname"), timeout)
-        conn = psycopg2.connect(connect_timeout=timeout, **params)
-        conn.autocommit = False
-        logger.info("Conexão aberta.")
-        return conn
+        logger.info(
+            "Conectando ao PostgreSQL em %s:%s/%s (timeout=%ss)...",
+            params.get("host"),
+            params.get("port"),
+            params.get("dbname"),
+            timeout,
+        )
+        try:
+            conn = psycopg2.connect(connect_timeout=timeout, **params)
+            conn.autocommit = False
+            logger.info("Conexão aberta.")
+            return conn
+        except OperationalError:
+            logger.exception("Erro operacional ao conectar ao banco de dados")
+            raise
+        except Exception:
+            logger.exception("Erro inesperado ao conectar ao banco de dados")
+            raise
 
     # ------------------------------------------------------------------
     def get_connection(self) -> connection:


### PR DESCRIPTION
## Summary
- log and re-raise database connection errors in `ConnectionManager.connect`

## Testing
- `pytest tests/test_connection_manager.py::test_connect_logs_operational_error -q`
- `pytest -q` *(fails: connection to server at "localhost" (::1), port 5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_68993d18a938832e92936fe96b6614e8