### PR TITLE
Avoid storing DB passwords in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,36 @@ O caminho informado em `log_path` é convertido para absoluto a partir de `BASE_
 
 Para sobrepor completamente as configurações, defina a variável de ambiente `IFSC_SGBD_CONFIG_FILE` apontando para um arquivo YAML alternativo ou edite o arquivo `config/config.yml` local.
 
-Senhas de banco de dados **não** devem ser armazenadas no arquivo de configuração. 
-O `ConnectionManager` buscará a senha a partir da variável de ambiente 
-`<NOME_DO_PERFIL>_PASSWORD` (por exemplo, `LOCAL_PASSWORD`) ou do serviço 
+Senhas de banco de dados **não** devem ser armazenadas no arquivo de configuração.
+O `ConnectionManager` buscará a senha a partir da variável de ambiente
+`<NOME_DO_PERFIL>_PASSWORD` (por exemplo, `LOCAL_PASSWORD`) ou do serviço
 `keyring` configurado para o usuário correspondente.
+
+Cada entrada em `config/config.yml` pode indicar explicitamente o nome da
+variável de ambiente com o campo `password_env`. Exemplo:
+
+```yaml
+databases:
+  - name: remoto
+    host: 172.16.0.228
+    user: postgres
+    password_env: REMOTO_PASSWORD
+```
+
+Em seguida, defina a variável de ambiente antes de executar a aplicação:
+
+```bash
+export REMOTO_PASSWORD='sua_senha'
+```
+
+Como alternativa, é possível registrar a senha no serviço `keyring`:
+
+```bash
+python - <<'PY'
+import keyring
+keyring.set_password('IFSC_SGBD', 'postgres', 'sua_senha')
+PY
+```
 
 ## Execução
 Para iniciar a interface gráfica do gerenciador, execute:

--- a/config/config.yml
+++ b/config/config.yml
@@ -2,13 +2,13 @@ databases:
 - dbname: Campus_Maruo_Ramos_db
   host: 172.16.0.228
   name: remoto
-  password: GeoIFSC2025
+  password_env: REMOTO_PASSWORD
   port: 5432
   user: postgres
 - dbname: Campus_Mauro_Ramos_db
   host: 172.16.0.228
   name: Geral
-  password: GeoIFSC2025
+  password_env: GERAL_PASSWORD
   port: 5432
   user: postgres
 group_prefix: grp_

--- a/gerenciador_postgres/connection_manager.py
+++ b/gerenciador_postgres/connection_manager.py
@@ -80,7 +80,7 @@ class ConnectionManager:
 
         password = profile.get("password")
         if password is None:
-            env_var = f"{profile_name.upper()}_PASSWORD"
+            env_var = profile.get("password_env") or f"{profile_name.upper()}_PASSWORD"
             password = os.getenv(env_var)
         if password is None:
             try:

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -134,3 +134,44 @@ def test_connect_to_env_password(monkeypatch):
     cm.connect_to("p")
     assert captured["password"] == "secret"
     cm.disconnect("p")
+
+
+def test_connect_to_custom_env_password(monkeypatch):
+    cm = ConnectionManager()
+
+    config = {
+        "databases": [
+            {
+                "name": "p",
+                "host": "h",
+                "user": "u",
+                "dbname": "d",
+                "password_env": "MY_SECRET",
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        "gerenciador_postgres.connection_manager.load_config", lambda: config
+    )
+    monkeypatch.setenv("MY_SECRET", "secret")
+
+    captured = {}
+
+    class DummyPool:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+
+        def getconn(self):
+            return MagicMock()
+
+        def putconn(self, conn):
+            pass
+
+    monkeypatch.setattr(
+        "gerenciador_postgres.connection_manager.SimpleConnectionPool",
+        lambda *a, **k: DummyPool(*a, **k),
+    )
+
+    cm.connect_to("p")
+    assert captured["password"] == "secret"
+    cm.disconnect("p")


### PR DESCRIPTION
## Summary
- load database passwords from environment variables or keyring
- document how to configure passwords securely
- test custom `password_env` support

## Testing
- `pytest` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6899416e9cbc832e9560a9256f882e4f