### PR TITLE
Configure root logger and propagate module logs

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -12,6 +12,6 @@ databases:
   port: 5432
   user: postgres
 group_prefix: grp_
-log_level: INFO
+log_level: DEBUG
 log_path: D:\GitHub\IFSC_SGBD\logs\app.log
 schema_creation_group: Professores

--- a/gerenciador_postgres/config_manager.py
+++ b/gerenciador_postgres/config_manager.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import yaml
 from .path_config import BASE_DIR, CONFIG_DIR as DEFAULT_CONFIG_DIR
+
 CONFIG_FILE_ENV = os.getenv("IFSC_SGBD_CONFIG_FILE")
 if CONFIG_FILE_ENV:
     CONFIG_FILE = Path(CONFIG_FILE_ENV)
@@ -11,16 +12,17 @@ if CONFIG_FILE_ENV:
     CONFIG_DIR = CONFIG_FILE.parent
 else:
     CONFIG_DIR = DEFAULT_CONFIG_DIR
-    CONFIG_FILE = CONFIG_DIR / 'config.yml'
+    CONFIG_FILE = CONFIG_DIR / "config.yml"
 
 DEFAULT_CONFIG = {
-    'log_path': str(BASE_DIR / 'logs' / 'app.log'),
-    'log_level': 'INFO',
-    'group_prefix': 'grp_',
-    'schema_creation_group': 'Professores'
+    "log_path": str(BASE_DIR / "logs" / "app.log"),
+    "log_level": "INFO",
+    "group_prefix": "grp_",
+    "schema_creation_group": "Professores",
 }
 
 logger = logging.getLogger(__name__)
+logger.propagate = True
 
 def load_config():
     if not CONFIG_FILE.exists():

--- a/gerenciador_postgres/connection_manager.py
+++ b/gerenciador_postgres/connection_manager.py
@@ -22,6 +22,7 @@ from .config_manager import load_config
 
 
 logger = logging.getLogger(__name__)
+logger.propagate = True
 
 
 class ConnectionManager:

--- a/gerenciador_postgres/db_manager.py
+++ b/gerenciador_postgres/db_manager.py
@@ -7,6 +7,7 @@ from typing import Optional, List, Dict, Set, Callable
 import logging
 
 logger = logging.getLogger(__name__)
+logger.propagate = True
 
 
 PRIVILEGE_WHITELIST = {

--- a/gerenciador_postgres/logger.py
+++ b/gerenciador_postgres/logger.py
@@ -4,22 +4,41 @@ from .path_config import BASE_DIR
 from .config_manager import load_config
 import os
 
-def setup_logger(name: str = 'app'):
+
+def setup_logger():
+    """Configure o logger raiz para arquivo e console.
+
+    Lê as configurações de ``config.yml`` e ajusta o *logger* raiz
+    (``logging.getLogger()``) para que todos os módulos do projeto possam
+    obter *loggers* específicos via ``logging.getLogger(__name__)`` e ainda
+    assim compartilhar a mesma configuração.
+    """
+
     try:
         config = load_config()
     except Exception:
-        config = {'log_path': str(BASE_DIR / 'logs' / 'app.log'), 'log_level': 'INFO'}
-    log_path = config.get('log_path', str(BASE_DIR / 'logs' / 'app.log'))
-    log_level = getattr(logging, config.get('log_level', 'INFO').upper(), logging.INFO)
+        config = {"log_path": str(BASE_DIR / "logs" / "app.log"), "log_level": "INFO"}
+
+    log_path = config.get("log_path", str(BASE_DIR / "logs" / "app.log"))
+    log_level = getattr(logging, config.get("log_level", "INFO").upper(), logging.INFO)
+
     os.makedirs(os.path.dirname(log_path), exist_ok=True)
-    logger = logging.getLogger(name)
+
+    logger = logging.getLogger()  # logger raiz
     logger.setLevel(log_level)
-    formatter = logging.Formatter('[%(asctime)s] %(levelname)s %(name)s: %(message)s')
-    file_handler = RotatingFileHandler(log_path, maxBytes=5*1024*1024, backupCount=3, encoding='utf-8')
+
+    formatter = logging.Formatter("[%(asctime)s] %(levelname)s %(name)s: %(message)s")
+
+    file_handler = RotatingFileHandler(
+        log_path, maxBytes=5 * 1024 * 1024, backupCount=3, encoding="utf-8"
+    )
     file_handler.setFormatter(formatter)
+
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(formatter)
+
     logger.handlers.clear()
     logger.addHandler(file_handler)
     logger.addHandler(stream_handler)
+
     return logger


### PR DESCRIPTION
## Summary
- Configure root logger with rotating file and console handlers
- Ensure module loggers propagate to root logger
- Set default log level to DEBUG

## Testing
- `pytest` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6899441e60e4832ea264040b4fc7ac9a