### PR TITLE
Configure automatic logging initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ O arquivo `config/config.yml` centraliza parâmetros do sistema. Nele é possív
 - `group_prefix`: prefixo obrigatório para nomes de grupos (padrão `"grp_"`).
 - `schema_creation_group`: nome do grupo autorizado a criar schemas (padrão `"Professores"`).
 
+Os logs são configurados automaticamente na importação do pacote e podem ser
+personalizados editando `config/config.yml`.
+
 Para permitir que outro grupo crie schemas, edite o valor de `schema_creation_group` em `config/config.yml` e reinicie a aplicação.
 
 O caminho informado em `log_path` é convertido para absoluto a partir de `BASE_DIR`, permitindo o uso de caminhos relativos.

--- a/gerenciador_postgres/connection_manager.py
+++ b/gerenciador_postgres/connection_manager.py
@@ -19,6 +19,7 @@ from psycopg2.extensions import connection
 from psycopg2.pool import SimpleConnectionPool
 
 from .config_manager import load_config
+from .logger import setup_logger
 
 
 logger = logging.getLogger(__name__)
@@ -57,6 +58,8 @@ class ConnectionManager:
         *thread* para um determinado perfil obtém uma conexão do pool e as
         próximas chamadas reutilizam a mesma instância.
         """
+        if not logging.getLogger('app').handlers:
+            setup_logger()
 
         config = load_config()
         profiles = {db["name"]: db for db in config.get("databases", [])}
@@ -114,6 +117,8 @@ class ConnectionManager:
         Conecta ao PostgreSQL com suporte a connect_timeout (segundos).
         Ex.: host, port, dbname, user, password, sslmode, connect_timeout.
         """
+        if not logging.getLogger('app').handlers:
+            setup_logger()
 
         timeout = int(params.pop("connect_timeout", 5) or 5)
         logger.info(

--- a/gerenciador_postgres/logger.py
+++ b/gerenciador_postgres/logger.py
@@ -23,3 +23,8 @@ def setup_logger(name: str = 'app'):
     logger.addHandler(file_handler)
     logger.addHandler(stream_handler)
     return logger
+
+
+# Configure default logger on module import if not already configured
+if not logging.getLogger('app').handlers:
+    setup_logger()


### PR DESCRIPTION
## Summary
- Automatically initialize logging on module import if the `app` logger lacks handlers
- Ensure `ConnectionManager` methods set up logging when needed
- Document automatic log configuration and customization in `config/config.yml`

## Testing
- `pytest` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68994452de2c832e9f3be157fdd7c27b