### PR TITLE
Add keyring password management to connection dialog

### DIFF
--- a/tests/test_connection_dialog_keyring.py
+++ b/tests/test_connection_dialog_keyring.py
@@ -1,0 +1,62 @@
+import os
+import sys
+from types import SimpleNamespace
+from PyQt6.QtWidgets import QMessageBox
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from gerenciador_postgres.gui.connection_dialog import ConnectionDialog
+
+
+def _make_dialog():
+    dlg = ConnectionDialog.__new__(ConnectionDialog)
+    dlg.chkSavePassword = SimpleNamespace(isChecked=lambda: True)
+    dlg.txtPassword = SimpleNamespace(text=lambda: "p")
+    dlg.txtUser = SimpleNamespace(text=lambda: "u")
+    dlg.update_password_indicator = lambda: None
+    dlg._keyring_warning_shown = False
+    return dlg
+
+
+def test_set_password_called(monkeypatch):
+    dlg = _make_dialog()
+
+    called = {}
+
+    def fake_set(service, user, pwd):
+        called["args"] = (service, user, pwd)
+
+    monkeypatch.setattr(
+        "gerenciador_postgres.gui.connection_dialog.keyring.set_password", fake_set
+    )
+    monkeypatch.setattr(
+        "gerenciador_postgres.gui.connection_dialog.QMessageBox.information",
+        lambda *a, **k: None,
+    )
+
+    dlg._maybe_save_password()
+    assert called["args"] == ("IFSC_SGBD", "u", "p")
+
+
+def test_delete_password_called(monkeypatch):
+    dlg = _make_dialog()
+
+    monkeypatch.setattr(
+        "gerenciador_postgres.gui.connection_dialog.QMessageBox.question",
+        lambda *a, **k: QMessageBox.StandardButton.Yes,
+    )
+    monkeypatch.setattr(
+        "gerenciador_postgres.gui.connection_dialog.QMessageBox.information",
+        lambda *a, **k: None,
+    )
+    deleted = {}
+
+    def fake_delete(service, user):
+        deleted["args"] = (service, user)
+
+    monkeypatch.setattr(
+        "gerenciador_postgres.gui.connection_dialog.keyring.delete_password", fake_delete
+    )
+
+    dlg.delete_saved_password()
+    assert deleted["args"] == ("IFSC_SGBD", "u")


### PR DESCRIPTION
## Summary
- Allow saving and deleting passwords via system keyring
- Indicate stored credentials and handle missing keyring backend
- Add unit tests for keyring save/delete behavior

## Testing
- `pytest tests/test_connection_manager.py tests/test_connection_dialog_keyring.py`
- `pytest` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689a2598a034832ebc3f17ab9a34e715