### PR TITLE
Keep dashboard visible after connection and improve layout

### DIFF
--- a/gerenciador_postgres/gui/initial_panel.py
+++ b/gerenciador_postgres/gui/initial_panel.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import platform
 from pathlib import Path
 
-from PyQt6.QtCore import PYQT_VERSION_STR, QT_VERSION_STR
+from PyQt6.QtCore import PYQT_VERSION_STR, QT_VERSION_STR, Qt
+from PyQt6.QtGui import QPixmap
 from PyQt6.QtWidgets import (
     QGridLayout,
     QGroupBox,
@@ -36,6 +37,14 @@ class InitialPanel(QWidget):
         layout.setSpacing(10)
         self.setLayout(layout)
 
+        assets_dir = Path(__file__).resolve().parents[2] / "assets"
+        banner = QLabel(self)
+        pixmap = QPixmap(str(assets_dir / "principal.jpeg"))
+        if not pixmap.isNull():
+            banner.setPixmap(pixmap.scaledToHeight(120, Qt.TransformationMode.SmoothTransformation))
+        banner.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(banner, 0, 0, 1, 2)
+
         self.app_box = QGroupBox("Aplicativo", self)
         self.env_box = QGroupBox("Ambiente", self)
         self.db_box = QGroupBox("Banco de Dados", self)
@@ -43,11 +52,14 @@ class InitialPanel(QWidget):
 
         for box in (self.app_box, self.env_box, self.db_box, self.check_box):
             box.setLayout(QVBoxLayout())
+            box.setStyleSheet(
+                "QGroupBox {background-color: #f9f9f9; border: 1px solid #d3d3d3; border-radius: 5px;}"
+            )
 
-        layout.addWidget(self.app_box, 0, 0)
-        layout.addWidget(self.env_box, 0, 1)
-        layout.addWidget(self.db_box, 1, 0)
-        layout.addWidget(self.check_box, 1, 1)
+        layout.addWidget(self.app_box, 1, 0)
+        layout.addWidget(self.env_box, 1, 1)
+        layout.addWidget(self.db_box, 2, 0)
+        layout.addWidget(self.check_box, 2, 1)
         layout.setColumnStretch(0, 1)
         layout.setColumnStretch(1, 1)
 

--- a/gerenciador_postgres/gui/main_window.py
+++ b/gerenciador_postgres/gui/main_window.py
@@ -219,10 +219,13 @@ class MainWindow(QMainWindow):
                 self.statusbar.showMessage(
                     f"Conectado a {params['dbname']} como {params['user']}"
                 )
-                self.stacked_widget.setCurrentWidget(self.mdi)
+                self.stacked_widget.setCurrentWidget(self.initial_panel)
 
                 QMessageBox.information(
-                    self, "Conexão bem-sucedida", f"Conectado ao banco {params['dbname']}.")
+                    self,
+                    "Conexão bem-sucedida",
+                    f"Conectado ao banco {params['dbname']}.",
+                )
 
             def finalize_fail(error: Exception):
                 if not getattr(self, "_connect_in_progress", False):
@@ -256,6 +259,7 @@ class MainWindow(QMainWindow):
 
         def handle_reject():
             sub_window.close()
+            self.stacked_widget.setCurrentWidget(self.initial_panel)
 
         dlg.accepted.connect(handle_accept)
         dlg.rejected.connect(handle_reject)


### PR DESCRIPTION
## Summary
- Keep initial dashboard visible after successful connection
- Add banner image and light styling to initial dashboard boxes

## Testing
- `pytest` (fails: OperationalError connecting to PostgreSQL; test_create_group_invalid_prefix failed)


------
https://chatgpt.com/codex/tasks/task_e_689a498602bc832e93203d70b6da175f