### PR TITLE
Fix password persistence and group prefix validation

### DIFF
--- a/gerenciador_postgres/gui/connection_dialog.py
+++ b/gerenciador_postgres/gui/connection_dialog.py
@@ -288,4 +288,10 @@ class ConnectionDialog(QDialog):  # caso já seja QDialog, mantenha
             self._show_keyring_unavailable()
         self.update_password_indicator()
 
+    # ------------------------------------------------------------------
+    def accept(self):
+        """Persiste a senha (quando solicitado) ao confirmar o diálogo."""
+        self._maybe_save_password()
+        super().accept()
+
     # A conexão é realizada pela MainWindow; este diálogo apenas coleta parâmetros.

--- a/gerenciador_postgres/role_manager.py
+++ b/gerenciador_postgres/role_manager.py
@@ -302,6 +302,8 @@ class RoleManager:
         try:
             config = load_config()
             prefix = config.get("group_prefix", "grp_")
+            if not prefix.startswith("grp_"):
+                raise ValueError("Prefixo de grupo inválido")
             # Sanitiza e aplica prefixo automaticamente
             group_name = self._sanitize_group_name(group_name, prefix=prefix)
             if group_name in self.dao.list_groups():

--- a/tests/test_connection_dialog_keyring.py
+++ b/tests/test_connection_dialog_keyring.py
@@ -60,3 +60,18 @@ def test_delete_password_called(monkeypatch):
 
     dlg.delete_saved_password()
     assert deleted["args"] == ("IFSC_SGBD", "u")
+
+
+def test_accept_triggers_save(monkeypatch):
+    dlg = _make_dialog()
+
+    called = {}
+
+    def fake_save():
+        called["called"] = True
+
+    dlg._maybe_save_password = fake_save
+    monkeypatch.setattr("PyQt6.QtWidgets.QDialog.accept", lambda self: None)
+
+    ConnectionDialog.accept(dlg)
+    assert called.get("called")


### PR DESCRIPTION
## Summary
- ensure ConnectionDialog saves keyring password when dialog is accepted
- validate group prefix configuration before creating groups
- add tests for dialog acceptance persisting password

## Testing
- `pytest -q -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_689a47808554832e9aa6cb108dca430e