### PR TITLE
feat: add SQL console view and menu option

### DIFF
--- a/gerenciador_postgres/gui/main_window.py
+++ b/gerenciador_postgres/gui/main_window.py
@@ -82,6 +82,7 @@ class MainWindow(QMainWindow):
         self.actionUsuarios = QAction("Usuários", self)
         self.actionGrupos = QAction("Grupos", self)
         self.actionAmbientes = QAction("Ambientes (Schemas)", self)
+        self.actionSqlConsole = QAction("Console SQL", self)
 
         # Ações do menu Ajuda
         self.actionAjuda = QAction("Ajuda", self)
@@ -94,6 +95,7 @@ class MainWindow(QMainWindow):
         self.actionUsuarios.triggered.connect(self.on_usuarios)
         self.actionGrupos.triggered.connect(self.on_grupos)
         self.actionAmbientes.triggered.connect(self.on_schemas)
+        self.actionSqlConsole.triggered.connect(self.on_sql_console)
 
         self.actionAjuda.triggered.connect(self.show_help)
         self.actionSobre.triggered.connect(self.show_about)
@@ -110,6 +112,7 @@ class MainWindow(QMainWindow):
         self.menuGerenciar.addAction(self.actionUsuarios)
         self.menuGerenciar.addAction(self.actionGrupos)
         self.menuGerenciar.addAction(self.actionAmbientes)
+        self.menuGerenciar.addAction(self.actionSqlConsole)
         self.menuGerenciar.setEnabled(False) # Começa desabilitado
 
         # Menu Ajuda
@@ -298,4 +301,19 @@ class MainWindow(QMainWindow):
             sub_window.show()
         else:
             QMessageBox.warning(self, "Não Conectado", "Você precisa estar conectado a um banco de dados para gerenciar schemas.")
+
+    def on_sql_console(self):
+        from .sql_console_view import SQLConsoleView
+        if self.db_manager:
+            self.stacked_widget.setCurrentWidget(self.mdi)
+            console = SQLConsoleView(self.db_manager, self)
+            sub_window = self.mdi.addSubWindow(console)
+            self.opened_windows.append(sub_window)
+            sub_window.show()
+        else:
+            QMessageBox.warning(
+                self,
+                "Não Conectado",
+                "Você precisa estar conectado a um banco de dados para executar SQL.",
+            )
     

--- a/gerenciador_postgres/gui/sql_console_view.py
+++ b/gerenciador_postgres/gui/sql_console_view.py
@@ -1,0 +1,60 @@
+from PyQt6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QTextEdit,
+    QPushButton,
+    QPlainTextEdit,
+)
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QIcon
+from pathlib import Path
+from ..db_manager import DBManager
+import psycopg2
+
+
+class SQLConsoleView(QWidget):
+    """Janela simples para executar comandos SQL."""
+
+    def __init__(self, db_manager: DBManager, parent: QWidget | None = None):
+        super().__init__(parent)
+        assets_dir = Path(__file__).resolve().parents[2] / "assets"
+        self.setWindowIcon(QIcon(str(assets_dir / "icone.png")))
+        self.setWindowTitle("Console SQL")
+        self.db_manager = db_manager
+        self._setup_ui()
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+        self.txtSQL = QTextEdit()
+        self.btnExecute = QPushButton("Executar")
+        self.txtResult = QPlainTextEdit()
+        self.txtResult.setReadOnly(True)
+        layout.addWidget(self.txtSQL)
+        layout.addWidget(self.btnExecute, alignment=Qt.AlignmentFlag.AlignRight)
+        layout.addWidget(self.txtResult)
+        self.btnExecute.clicked.connect(self.on_execute)
+
+    def on_execute(self):
+        sql_text = self.txtSQL.toPlainText().strip()
+        if not sql_text:
+            return
+        conn = self.db_manager.conn
+        try:
+            with conn.cursor() as cur:
+                statements = [s.strip() for s in sql_text.split(";") if s.strip()]
+                output_lines: list[str] = []
+                for stmt in statements:
+                    cur.execute(stmt)
+                    if cur.description:
+                        rows = cur.fetchall()
+                        headers = [d[0] for d in cur.description]
+                        output_lines.append("\t".join(headers))
+                        for row in rows:
+                            output_lines.append("\t".join(str(col) for col in row))
+                    else:
+                        output_lines.append(f"{cur.rowcount} linha(s) afetadas.")
+                conn.commit()
+                self.txtResult.setPlainText("\n".join(output_lines) or "Comando executado.")
+        except psycopg2.Error as e:
+            conn.rollback()
+            self.txtResult.setPlainText(f"Erro: {e}")


### PR DESCRIPTION
## Summary
- integrate SQL console action into main menu
- implement SQLConsoleView to run arbitrary SQL and display results

## Testing
- `python -m pytest` *(fails: RuntimeError in ConnectionDialog tests; OperationalError when connecting to database)*

------
https://chatgpt.com/codex/tasks/task_e_689a6dedc03c832ea040529ef624d5fd