### PR TITLE
Add font size controls to SQL console view

### DIFF
--- a/gerenciador_postgres/gui/sql_console_view.py
+++ b/gerenciador_postgres/gui/sql_console_view.py
@@ -1,12 +1,13 @@
 from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
+    QHBoxLayout,
     QTextEdit,
     QPushButton,
     QPlainTextEdit,
 )
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QIcon
+from PyQt6.QtGui import QIcon, QFont
 from pathlib import Path
 from ..db_manager import DBManager
 import psycopg2
@@ -27,12 +28,25 @@ class SQLConsoleView(QWidget):
         layout = QVBoxLayout(self)
         self.txtSQL = QTextEdit()
         self.btnExecute = QPushButton("Executar")
+        self.btnIncrease = QPushButton("+")
+        self.btnDecrease = QPushButton("-")
         self.txtResult = QPlainTextEdit()
         self.txtResult.setReadOnly(True)
+
+        button_layout = QHBoxLayout()
+        button_layout.addWidget(self.btnDecrease)
+        button_layout.addWidget(self.btnIncrease)
+        button_layout.addStretch()
+        button_layout.addWidget(self.btnExecute)
+
         layout.addWidget(self.txtSQL)
-        layout.addWidget(self.btnExecute, alignment=Qt.AlignmentFlag.AlignRight)
+        layout.addLayout(button_layout)
         layout.addWidget(self.txtResult)
+
         self.btnExecute.clicked.connect(self.on_execute)
+        self.btnIncrease.clicked.connect(self.increase_font)
+        self.btnDecrease.clicked.connect(self.decrease_font)
+        self.font_size = self.txtSQL.font().pointSize()
 
     def on_execute(self):
         sql_text = self.txtSQL.toPlainText().strip()
@@ -58,3 +72,18 @@ class SQLConsoleView(QWidget):
         except psycopg2.Error as e:
             conn.rollback()
             self.txtResult.setPlainText(f"Erro: {e}")
+
+    def _set_font_size(self):
+        font = QFont(self.txtSQL.font())
+        font.setPointSize(self.font_size)
+        self.txtSQL.setFont(font)
+        self.txtResult.setFont(font)
+
+    def increase_font(self):
+        self.font_size += 1
+        self._set_font_size()
+
+    def decrease_font(self):
+        if self.font_size > 1:
+            self.font_size -= 1
+            self._set_font_size()


### PR DESCRIPTION
## Summary
- Add buttons to increase and decrease font size in SQL console
- Apply new font size to both SQL input and result widgets using QFont

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689c8ffdb244832e975631f1779a5340