### PR TITLE
Implement privilege retrieval and privilege view integration

### DIFF
--- a/gerenciador_postgres/controllers/groups_controller.py
+++ b/gerenciador_postgres/controllers/groups_controller.py
@@ -46,6 +46,12 @@ class GroupsController(QObject):
     def get_group_privileges(self, group_name: str):
         return self.role_manager.get_group_privileges(group_name)
 
+    def get_database_privileges(self, role_name: str):
+        return self.role_manager.get_database_privileges(role_name)
+
+    def get_schema_privileges(self, role_name: str):
+        return self.role_manager.get_schema_privileges(role_name)
+
     def list_privilege_templates(self):
         return PERMISSION_TEMPLATES
 

--- a/gerenciador_postgres/gui/privileges_view.py
+++ b/gerenciador_postgres/gui/privileges_view.py
@@ -151,6 +151,42 @@ class PrivilegesView(QWidget):
         self.treeSchemaPrivileges.expandAll()
         self.treeTablePrivileges.expandAll()
 
+        role = self.cmbRole.currentText()
+        if not role:
+            return
+        try:
+            db_privs = self.controller.get_database_privileges(role)
+            db_item = self.treeDbPrivileges.topLevelItem(0)
+            for col, label in enumerate(["CONNECT", "CREATE", "TEMP"], start=1):
+                if label in db_privs:
+                    db_item.setCheckState(col, Qt.CheckState.Checked)
+
+            schema_privs = self.controller.get_schema_privileges(role)
+            for i in range(self.treeSchemaPrivileges.topLevelItemCount()):
+                schema_item = self.treeSchemaPrivileges.topLevelItem(i)
+                schema = schema_item.text(0)
+                perms = schema_privs.get(schema, set())
+                for col, label in enumerate(["USAGE", "CREATE"], start=1):
+                    if label in perms:
+                        schema_item.setCheckState(col, Qt.CheckState.Checked)
+
+            table_privs = self.controller.get_group_privileges(role)
+            for i in range(self.treeTablePrivileges.topLevelItemCount()):
+                schema_item = self.treeTablePrivileges.topLevelItem(i)
+                schema = schema_item.text(0)
+                tables = table_privs.get(schema, {})
+                for j in range(schema_item.childCount()):
+                    table_item = schema_item.child(j)
+                    table = table_item.text(0)
+                    perms = tables.get(table, set())
+                    for col, label in enumerate(
+                        ["SELECT", "INSERT", "UPDATE", "DELETE"], start=1
+                    ):
+                        if label in perms:
+                            table_item.setCheckState(col, Qt.CheckState.Checked)
+        except Exception as e:
+            QMessageBox.critical(self, "Erro", f"Falha ao carregar privilégios: {e}")
+
     # ------------------------------------------------------------------
     # Ações
     # ------------------------------------------------------------------

--- a/gerenciador_postgres/role_manager.py
+++ b/gerenciador_postgres/role_manager.py
@@ -439,6 +439,24 @@ class RoleManager:
             )
             return {}
 
+    def get_database_privileges(self, role_name: str) -> Set[str]:
+        try:
+            return self.dao.get_database_privileges(role_name)
+        except Exception as e:
+            self.logger.error(
+                f"[{self.operador}] Erro ao obter privilégios de banco para '{role_name}': {e}"
+            )
+            return set()
+
+    def get_schema_privileges(self, role_name: str) -> Dict[str, Set[str]]:
+        try:
+            return self.dao.get_schema_privileges(role_name)
+        except Exception as e:
+            self.logger.error(
+                f"[{self.operador}] Erro ao obter privilégios de schema para '{role_name}': {e}"
+            )
+            return {}
+
     def set_group_privileges(
         self,
         group_name: str,

--- a/tests/test_db_manager_privilege_read.py
+++ b/tests/test_db_manager_privilege_read.py
@@ -1,0 +1,73 @@
+import sys
+import pathlib
+import unittest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from gerenciador_postgres.db_manager import DBManager
+
+
+class DummyCursor:
+    def __init__(self, db_privs, schema_privs):
+        self.db_privs = db_privs
+        self.schema_privs = schema_privs
+        self.result = []
+        self.last_query = ""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql, params=None):
+        self.last_query = sql
+        if "has_database_privilege" in sql:
+            role, priv = params
+            priv = "TEMP" if priv == "TEMPORARY" else priv
+            self.result = [(priv in self.db_privs.get(role, set()),)]
+        elif "information_schema.schema_privileges" in sql:
+            role = params[0]
+            rows = []
+            for schema, privs in self.schema_privs.get(role, {}).items():
+                for p in privs:
+                    rows.append((schema, p))
+            self.result = rows
+        else:
+            self.result = []
+
+    def fetchone(self):
+        return self.result[0] if self.result else None
+
+    def fetchall(self):
+        return self.result
+
+
+class DummyConn:
+    def __init__(self, db_privs, schema_privs):
+        self.db_privs = db_privs
+        self.schema_privs = schema_privs
+
+    def cursor(self):
+        return DummyCursor(self.db_privs, self.schema_privs)
+
+    def get_dsn_parameters(self):
+        return {"dbname": "testdb"}
+
+
+class DBManagerPrivilegeReadTests(unittest.TestCase):
+    def setUp(self):
+        db_privs = {"role1": {"CONNECT", "TEMP"}}
+        schema_privs = {"role1": {"public": {"USAGE"}}}
+        self.dbm = DBManager(DummyConn(db_privs, schema_privs))
+
+    def test_get_database_privileges(self):
+        self.assertEqual(self.dbm.get_database_privileges("role1"), {"CONNECT", "TEMP"})
+
+    def test_get_schema_privileges(self):
+        expected = {"public": {"USAGE"}}
+        self.assertEqual(self.dbm.get_schema_privileges("role1"), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_privileges_view_marking.py
+++ b/tests/test_privileges_view_marking.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import pathlib
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtWidgets import QApplication
+from PyQt6.QtCore import QObject, pyqtSignal, Qt
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from gerenciador_postgres.gui.privileges_view import PrivilegesView
+
+
+class DummyController(QObject):
+    data_changed = pyqtSignal()
+
+    def __init__(self):
+        super().__init__()
+
+    def list_entities(self):
+        return ["role1"], []
+
+    def get_schema_tables(self, **kwargs):
+        return {"public": ["t1"]}
+
+    def get_group_privileges(self, role):
+        return {"public": {"t1": {"SELECT"}}}
+
+    def get_database_privileges(self, role):
+        return {"CONNECT"}
+
+    def get_schema_privileges(self, role):
+        return {"public": {"USAGE"}}
+
+    def apply_template_to_group(self, *args, **kwargs):
+        return True
+
+    def grant_database_privileges(self, *args, **kwargs):
+        return True
+
+    def grant_schema_privileges(self, *args, **kwargs):
+        return True
+
+    def apply_group_privileges(self, *args, **kwargs):
+        return True
+
+    def get_current_database(self):
+        return "testdb"
+
+
+def test_populate_tree_marks_privileges():
+    app = QApplication.instance() or QApplication([])
+    controller = DummyController()
+    view = PrivilegesView(controller=controller)
+    db_item = view.treeDbPrivileges.topLevelItem(0)
+    assert db_item.checkState(1) == Qt.CheckState.Checked
+    assert db_item.checkState(2) == Qt.CheckState.Unchecked
+    schema_item = view.treeSchemaPrivileges.topLevelItem(0)
+    assert schema_item.checkState(1) == Qt.CheckState.Checked
+    table_schema_item = view.treeTablePrivileges.topLevelItem(0)
+    table_item = table_schema_item.child(0)
+    assert table_item.checkState(1) == Qt.CheckState.Checked
+    view.close()


### PR DESCRIPTION
## Summary
- add database and schema privilege readers in `DBManager`
- expose privilege getters via `RoleManager` and `GroupsController`
- populate privilege view with existing permissions and add tests

## Testing
- `pytest`
- `pytest tests/test_db_manager_privilege_read.py tests/test_privileges_view_marking.py`


------
https://chatgpt.com/codex/tasks/task_e_689d25f98670832eaacab5a93238caf5