### PR TITLE
Ensure group schema privilege retrieval and GUI error handling

### DIFF
--- a/gerenciador_postgres/gui/groups_view.py
+++ b/gerenciador_postgres/gui/groups_view.py
@@ -19,6 +19,7 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtCore import Qt, QThread, pyqtSignal
 from PyQt6.QtGui import QIcon
 from pathlib import Path
+import logging
 
 
 class _TaskRunner(QThread):
@@ -240,10 +241,19 @@ class GroupsView(QWidget):
     def _populate_tree(self):
         if not self.controller or not self.current_group:
             return
-        data = self.controller.get_schema_tables()
-        privileges = self.controller.get_group_privileges(self.current_group)
-        schema_level = self.controller.get_schema_level_privileges(self.current_group)
-        future_defaults = self.controller.get_default_table_privileges(self.current_group)
+        try:
+            data = self.controller.get_schema_tables()
+            privileges = self.controller.get_group_privileges(self.current_group)
+            schema_level = self.controller.get_schema_level_privileges(self.current_group)
+            future_defaults = self.controller.get_default_table_privileges(self.current_group)
+        except Exception as e:  # pragma: no cover
+            logging.exception("Erro ao ler privilégios do grupo")
+            QMessageBox.warning(
+                self,
+                "Erro",
+                f"Não foi possível ler os privilégios.\nMotivo: {e}",
+            )
+            data, privileges, schema_level, future_defaults = {}, {}, {}, {}
         self.treePrivileges.clear()
         for schema, tables in data.items():
             schema_item = QTreeWidgetItem([schema])

--- a/tests/test_schema_privileges_group.py
+++ b/tests/test_schema_privileges_group.py
@@ -1,0 +1,88 @@
+import os
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from gerenciador_postgres.db_manager import DBManager
+from gerenciador_postgres.gui.groups_view import GroupsView
+from PyQt6.QtWidgets import QApplication, QTreeWidget, QListWidget, QPushButton
+from PyQt6.QtCore import Qt
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+class DummyCursor:
+    def __init__(self, conn):
+        self.conn = conn
+        self.result = []
+        self.commands = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql, params=None):
+        self.commands.append(sql)
+        sql_str = str(sql)
+        if "information_schema.schema_privileges" in sql_str:
+            self.result = [
+                (schema, priv)
+                for schema, privs in self.conn.grants.items()
+                for priv in sorted(privs)
+            ]
+        else:
+            self.result = []
+
+    def fetchall(self):
+        return self.result
+
+
+class DummyConn:
+    def __init__(self):
+        self.grants = {}
+        self.last_cursor = None
+
+    def cursor(self):
+        self.last_cursor = DummyCursor(self)
+        return self.last_cursor
+
+
+def test_grant_and_display_schema_privileges():
+    app = QApplication.instance() or QApplication([])
+    conn = DummyConn()
+    dbm = DBManager(conn)
+    dbm.grant_schema_privileges("grp_role", "public", {"USAGE", "CREATE"})
+    assert len(conn.last_cursor.commands) == 2
+    conn.grants = {"public": {"USAGE", "CREATE"}}
+    privs = dbm.get_schema_privileges("grp_role")
+    assert privs == {"public": {"USAGE", "CREATE"}}
+
+    class DummyController:
+        def get_schema_tables(self):
+            return {"public": []}
+
+        def get_group_privileges(self, group):
+            return {}
+
+        def get_schema_level_privileges(self, group):
+            return privs
+
+        def get_default_table_privileges(self, group):
+            return {}
+
+    view = GroupsView.__new__(GroupsView)
+    view.controller = DummyController()
+    view.current_group = "grp_role"
+    view.treePrivileges = QTreeWidget()
+    view.btnApplyTemplate = QPushButton()
+    view.btnSave = QPushButton()
+    view.btnSweep = QPushButton()
+    view.lstMembers = QListWidget()
+    view._populate_tree()
+
+    general_item = view.treePrivileges.topLevelItem(0).child(0)
+    assert general_item.checkState(5) == Qt.CheckState.Checked
+    assert general_item.checkState(6) == Qt.CheckState.Checked


### PR DESCRIPTION
## Summary
- Query `information_schema.schema_privileges` to reliably read schema USAGE/CREATE grants for group roles
- Guard privilege loading in `GroupsView` and log/display errors to users
- Add regression test validating grant and display of schema privileges for a group

## Testing
- `pytest tests/test_schema_privileges_group.py -q`
- `pytest -q` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689d2c5c397c832ea83e05495fed577d