### PR TITLE
Handle short rows when fetching schema privileges

### DIFF
--- a/gerenciador_postgres/db_manager.py
+++ b/gerenciador_postgres/db_manager.py
@@ -426,7 +426,14 @@ class DBManager:
                 """,
                 (role,),
             )
-            for schema, privilege in cur.fetchall():
+            # Some database adapters may return rows with an unexpected
+            # number of columns.  To avoid ``IndexError`` in those cases
+            # we iterate over the raw rows and guard against short tuples.
+            for row in cur.fetchall():
+                if len(row) < 2:
+                    # Skip malformed rows instead of raising an error
+                    continue
+                schema, privilege = row[0], row[1]
                 out.setdefault(schema, set()).add(privilege)
         return out
 

--- a/tests/test_get_schema_privileges_safe.py
+++ b/tests/test_get_schema_privileges_safe.py
@@ -1,0 +1,37 @@
+import pytest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from gerenciador_postgres.db_manager import DBManager
+
+
+class DummyCursor:
+    def __init__(self):
+        # Include a malformed row with only one column to simulate unexpected
+        # database adapter behaviour.
+        self.result = [("public", "USAGE"), ("broken",)]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql, params=None):
+        pass
+
+    def fetchall(self):
+        return self.result
+
+
+class DummyConn:
+    def cursor(self):
+        return DummyCursor()
+
+
+def test_get_schema_privileges_handles_short_rows():
+    dbm = DBManager(DummyConn())
+    privs = dbm.get_schema_privileges("grp")
+    assert privs == {"public": {"USAGE"}}


### PR DESCRIPTION
## Summary
- Guard against malformed result tuples in `get_schema_privileges`
- Add regression test to ensure short rows don't raise `IndexError`

## Testing
- `pytest tests/test_get_schema_privileges_safe.py -q`
- `pytest -q` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689dcdd0bcec832eb1617e8cc5410117