### PR TITLE
Handle PostGIS extension dependencies in tests

### DIFF
--- a/tests/integration/test_postgres_integration.py
+++ b/tests/integration/test_postgres_integration.py
@@ -114,8 +114,9 @@ def test_default_privileges(conn):
 
 def test_enable_postgis(conn):
     db = DBManager(conn)
+    conn.rollback()
     cur = conn.cursor()
-    cur.execute("DROP EXTENSION IF EXISTS postgis")
+    cur.execute("DROP EXTENSION IF EXISTS postgis CASCADE")
     conn.commit()
     with db.transaction():
         db.enable_postgis("public")
@@ -125,6 +126,7 @@ def test_enable_postgis(conn):
 
 def test_apply_group_privileges_rollback(conn):
     db = DBManager(conn)
+    conn.rollback()
     cur = conn.cursor()
     cur.execute("DROP TABLE IF EXISTS public.t_valid")
     cur.execute("DROP ROLE IF EXISTS conflict_role")


### PR DESCRIPTION
## Summary
- Drop PostGIS extension with CASCADE in integration tests
- Roll back connections before integration tests to avoid aborted transactions

## Testing
- `pytest -m integration`

------
https://chatgpt.com/codex/tasks/task_e_689df070c3e0832ebd4fbef0164522d2