### PR TITLE
Handle malformed rows in schema privilege lookup

### DIFF
--- a/gerenciador_postgres/db_manager.py
+++ b/gerenciador_postgres/db_manager.py
@@ -427,15 +427,15 @@ class DBManager:
                 (role,),
             )
             # Some database adapters may yield rows with fewer columns or a
-            # non-sequence type.  Safely extract the expected values and skip
-            # anything that doesn't match the ``(schema, privilege)`` format.
+            # completely unexpected object.  Rather than failing with an
+            # ``IndexError`` or ``TypeError`` in those situations, ensure the
+            # row looks like a two element sequence before trying to unpack it.
             for row in cur.fetchall():
-                try:
-                    schema, privilege = row[0], row[1]
-                except (IndexError, TypeError):
+                if not isinstance(row, (list, tuple)) or len(row) < 2:
                     # Skip malformed or unexpected row formats instead of
                     # raising an error that would break the UI.
                     continue
+                schema, privilege = row[0], row[1]
                 out.setdefault(schema, set()).add(privilege)
         return out
 

--- a/tests/test_get_schema_privileges_safe.py
+++ b/tests/test_get_schema_privileges_safe.py
@@ -9,9 +9,10 @@ from gerenciador_postgres.db_manager import DBManager
 
 class DummyCursor:
     def __init__(self):
-        # Include a malformed row with only one column to simulate unexpected
-        # database adapter behaviour.
-        self.result = [("public", "USAGE"), ("broken",)]
+        # Include malformed rows: one with only a single column and one that is
+        # not a sequence at all to simulate unexpected database adapter
+        # behaviour.
+        self.result = [("public", "USAGE"), ("broken",), None]
 
     def __enter__(self):
         return self


### PR DESCRIPTION
## Summary
- Guard against malformed rows when retrieving schema privileges to avoid IndexError
- Extend tests for get_schema_privileges to cover short and non-sequence rows

## Testing
- `pytest` *(fails: connection to server at "127.0.0.1", port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e08fed644832e882d1a8ca9b65e1d