### PR TITLE
Simplify default privileges query

### DIFF
--- a/gerenciador_postgres/db_manager.py
+++ b/gerenciador_postgres/db_manager.py
@@ -538,9 +538,8 @@ class DBManager:
                 FROM pg_default_acl d
                 JOIN pg_namespace n ON n.oid = d.defaclnamespace
                 JOIN pg_roles owner_rol ON owner_rol.oid = d.defaclrole
-                CROSS JOIN LATERAL aclexplode(d.defaclacl) AS x(grantee, grantor, privs)
-                JOIN pg_roles grantee_rol ON grantee_rol.oid = x.grantee
-                CROSS JOIN LATERAL unnest(x.privs) AS priv(privilege_type, is_grantable)
+                CROSS JOIN LATERAL aclexplode(d.defaclacl) AS priv(grantee, grantor, privilege_type, is_grantable)
+                JOIN pg_roles grantee_rol ON grantee_rol.oid = priv.grantee
                 WHERE d.defaclobjtype = %(objtype)s
                 {role_filter}
                 GROUP BY n.nspname, owner_rol.rolname, grantee_rol.rolname


### PR DESCRIPTION
## Summary
- streamline SQL for default privileges on PostgreSQL 12+ by using single aclexplode join

## Testing
- `pytest` *(fails: OperationalError connecting to DB for integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_689e392ba08c832e99e1519cad2656e3