### PR TITLE
feat: improve default privilege handling

### DIFF
--- a/gerenciador_postgres/gui/groups_view.py
+++ b/gerenciador_postgres/gui/groups_view.py
@@ -328,9 +328,11 @@ class GroupsView(QWidget):
             schema_privs = self.controller.get_schema_level_privileges(role).get(
                 schema_name, set()
             )
-            default_privs = self.controller.get_default_table_privileges(role).get(
-                schema_name, set()
+            default_info = self.controller.get_default_table_privileges(role).get(
+                schema_name, {}
             )
+            default_privs = default_info.get("privileges", set())
+            owner_role = default_info.get("owner")
         except Exception as e:  # pragma: no cover
             logging.exception("Erro ao ler privilégios de schema")
             QMessageBox.warning(
@@ -338,7 +340,7 @@ class GroupsView(QWidget):
                 "Erro",
                 f"Não foi possível ler os privilégios.\nMotivo: {e}",
             )
-            schema_privs, default_privs = set(), set()
+            schema_privs, default_privs, owner_role = set(), set(), None
 
         usage_create_box = QGroupBox("Permissões no Schema")
         usage_create_layout = QHBoxLayout()
@@ -367,6 +369,10 @@ class GroupsView(QWidget):
         defaults_layout.addWidget(self.cb_default_delete)
         defaults_box.setLayout(defaults_layout)
         self.schema_details_layout.addWidget(defaults_box)
+
+        if owner_role:
+            owner_label = QLabel(f"owner: {owner_role}")
+            self.schema_details_layout.addWidget(owner_label)
 
         self.schema_details_layout.addStretch()
 

--- a/gerenciador_postgres/gui/privileges_view.py
+++ b/gerenciador_postgres/gui/privileges_view.py
@@ -128,7 +128,7 @@ class PrivilegesView(QWidget):
         role = self.cmbRole.currentText()
         data = self.controller.get_schema_tables()
         schema_privs = self.controller.get_schema_level_privileges(role)
-        default_privs = self.controller.get_default_table_privileges(role)
+        default_info = self.controller.get_default_table_privileges(role)
 
         # Banco
         self.treeDbPrivileges.clear()
@@ -147,6 +147,10 @@ class PrivilegesView(QWidget):
         self._clear_layout(self.schemaLayout)
         self.schema_checkboxes.clear()
         for schema in data.keys():
+            info = default_info.get(schema, {})
+            privs = info.get("privileges", set())
+            owner_role = info.get("owner")
+
             box = QGroupBox(schema)
             box_layout = QVBoxLayout()
 
@@ -162,17 +166,19 @@ class PrivilegesView(QWidget):
             row2 = QHBoxLayout()
             row2.addWidget(QLabel("Padrão para Novas Tabelas:"))
             cb_select = QCheckBox("SELECT")
-            cb_select.setChecked("SELECT" in default_privs.get(schema, set()))
+            cb_select.setChecked("SELECT" in privs)
             row2.addWidget(cb_select)
             cb_insert = QCheckBox("INSERT")
-            cb_insert.setChecked("INSERT" in default_privs.get(schema, set()))
+            cb_insert.setChecked("INSERT" in privs)
             row2.addWidget(cb_insert)
             cb_update = QCheckBox("UPDATE")
-            cb_update.setChecked("UPDATE" in default_privs.get(schema, set()))
+            cb_update.setChecked("UPDATE" in privs)
             row2.addWidget(cb_update)
             cb_delete = QCheckBox("DELETE")
-            cb_delete.setChecked("DELETE" in default_privs.get(schema, set()))
+            cb_delete.setChecked("DELETE" in privs)
             row2.addWidget(cb_delete)
+            if owner_role:
+                row2.addWidget(QLabel(f"owner: {owner_role}"))
             box_layout.addLayout(row2)
 
             box.setLayout(box_layout)

--- a/tests/test_db_manager_default_privileges.py
+++ b/tests/test_db_manager_default_privileges.py
@@ -11,6 +11,7 @@ class DummyCursor:
     def __init__(self):
         self.executed = []
         self.connection = None
+        self.result = []
 
     def __enter__(self):
         return self
@@ -19,7 +20,18 @@ class DummyCursor:
         pass
 
     def execute(self, sql, params=None):
-        self.executed.append(str(sql))
+        sql_str = str(sql)
+        self.executed.append(sql_str)
+        if "server_version_num" in sql_str:
+            self.result = [(150000,)]
+        else:
+            self.result = []
+
+    def fetchone(self):
+        return self.result[0] if self.result else None
+
+    def fetchall(self):
+        return self.result
 
 
 class DummyConn:


### PR DESCRIPTION
## Summary
- avoid unnecessary ALTER DEFAULT PRIVILEGES when privileges already applied
- return default privilege owners and guard concurrent UI refreshes
- display owner information in privilege views

## Testing
- `pytest tests/test_db_manager_default_privileges.py::DBManagerDefaultPrivTests::test_alter_default_privileges -q`
- `pytest -q` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689e3dfd5724832e9a788b30e17fcd78