### PR TITLE
Avoid sweep after altering default privileges

### DIFF
--- a/gerenciador_postgres/controllers/groups_controller.py
+++ b/gerenciador_postgres/controllers/groups_controller.py
@@ -134,8 +134,11 @@ class GroupsController(QObject):
                 group_name, schema, obj_type, privileges
             )
             if success:
+                # READ-BACK: reconsulta apenas os defaults do grupo/objeto-alvo
+                code_map = {"tables": "r", "sequences": "S", "functions": "f", "types": "T"}
+                code = code_map.get(obj_type, "r")
                 try:
-                    self.role_manager.sweep_privileges(target_group=group_name)
+                    self.role_manager.dao.get_default_privileges(group_name, code)
                 except Exception:
                     pass
                 self.data_changed.emit()

--- a/gerenciador_postgres/db_manager.py
+++ b/gerenciador_postgres/db_manager.py
@@ -643,10 +643,13 @@ class DBManager:
         current = self.get_default_privileges(group, code)
         existing = current.get(schema, {}).get(group, set())
         if existing == set(privileges):
-            logger.info(
-                f"ℹ️ Default privileges in schema '{schema}' for '{group}' already {sorted(privileges)}"
+            logger.debug(
+                "Default privileges in schema '%s' for '%s' unchanged: %s",
+                schema,
+                group,
+                sorted(privileges),
             )
-            logger.debug(f"=== alter_default_privileges END (no-op) ===")
+            logger.debug("=== alter_default_privileges END (no-op) ===")
             return
 
         identifier = sql.Identifier(schema)


### PR DESCRIPTION
## Summary
- Avoid sweeping privileges after altering default privileges and refresh data via read-back
- Downgrade no-op default privilege logs to debug level

## Testing
- `pytest` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689e451035ac832e92275166854351c2