### PR TITLE
Add warning label to SQL console about unsupported named parameters

### DIFF
--- a/gerenciador_postgres/gui/sql_console_view.py
+++ b/gerenciador_postgres/gui/sql_console_view.py
@@ -65,6 +65,11 @@ class SQLConsoleView(QWidget):
         query_layout.addWidget(self.btnDeleteQuery)
         layout.addLayout(query_layout)
 
+        self.lblLiteralWarning = QLabel(
+            "Use literais; parâmetros nomeados não são suportados aqui."
+        )
+        layout.addWidget(self.lblLiteralWarning)
+
         # SQL editor and results
         self.txtSQL = QTextEdit()
         self.txtSQL.setTabStopDistance(


### PR DESCRIPTION
## Summary
- Warn users that SQL console only accepts literal values by adding a label before the editor.

## Testing
- `pytest` *(errors: connection to PostgreSQL at localhost:5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_689e69fe7bf8832e9bdda1ab4f413f90