### PR TITLE
Avoid redundant sweep when defaults already applied

### DIFF
--- a/gerenciador_postgres/controllers/groups_controller.py
+++ b/gerenciador_postgres/controllers/groups_controller.py
@@ -97,11 +97,11 @@ class GroupsController(QObject):
             defaults_applied=defaults_applied,
         )
         if success:
-            # Sincroniza defaults para refletir os privilégios aplicados
-            try:
-                self.role_manager.sweep_privileges(target_group=group_name)
-            except Exception:
-                pass
+            if not defaults_applied:
+                try:
+                    self.role_manager.sweep_privileges(target_group=group_name)
+                except Exception:
+                    pass
             self.data_changed.emit()
         return success
 


### PR DESCRIPTION
## Summary
- Only sweep privileges when defaults have not been applied yet in `apply_group_privileges`

## Testing
- `pytest` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689e6d143b0c832e935539845c59c765