### PR TITLE
Add optional sweep skipping for schema privilege grants

### DIFF
--- a/gerenciador_postgres/controllers/groups_controller.py
+++ b/gerenciador_postgres/controllers/groups_controller.py
@@ -121,13 +121,20 @@ class GroupsController(QObject):
             self.data_changed.emit()
         return success
 
-    def grant_schema_privileges(self, group_name: str, schema: str, privileges):
+    def grant_schema_privileges(
+        self,
+        group_name: str,
+        schema: str,
+        privileges,
+        skip_sweep: bool = False,
+    ):
         success = self.role_manager.grant_schema_privileges(group_name, schema, privileges)
         if success:
-            try:
-                self.role_manager.sweep_privileges(target_group=group_name)
-            except Exception:
-                pass
+            if not skip_sweep:
+                try:
+                    self.role_manager.sweep_privileges(target_group=group_name)
+                except Exception:
+                    pass
             self.data_changed.emit()
         return success
 


### PR DESCRIPTION
## Summary
- Allow skipping automatic privilege sweep when granting schema privileges
- Defer sweeping group privileges in GUI when schema defaults are set

## Testing
- `pytest -q` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e6fee74b0832e9c25e4d2f0f2e546