### PR TITLE
Handle empty default privileges correctly

### DIFF
--- a/gerenciador_postgres/gui/privileges_view.py
+++ b/gerenciador_postgres/gui/privileges_view.py
@@ -359,15 +359,16 @@ class PrivilegesView(QWidget):
                 ok &= self.controller.grant_schema_privileges(
                     role, schema, perms, skip_sweep=skip_sweep
                 )
-            defaults_applied = any(default_privs.values())
+            defaults_applied = any(perms for perms in default_privs.values())
             for schema, perms in default_privs.items():
-                ok &= self.controller.alter_default_privileges(
-                    role,
-                    schema,
-                    "tables",
-                    perms,
-                    owner=default_owners.get(schema),
-                )
+                if perms:
+                    ok &= self.controller.alter_default_privileges(
+                        role,
+                        schema,
+                        "tables",
+                        perms,
+                        owner=default_owners.get(schema),
+                    )
             ok &= self.controller.apply_group_privileges(
                 role,
                 table_privileges,


### PR DESCRIPTION
## Summary
- Avoid altering default privileges when no permissions selected
- Compute defaults_applied based on non-empty permission sets
- Pass accurate defaults_applied flag when applying group privileges

## Testing
- `pytest -q` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689e73aa4674832e81cc77485ea8d6a1