### PR TITLE
Refine default privilege loading

### DIFF
--- a/gerenciador_postgres/controllers/groups_controller.py
+++ b/gerenciador_postgres/controllers/groups_controller.py
@@ -64,7 +64,7 @@ class GroupsController(QObject):
             return {}
         self._is_refreshing = True
         try:
-            data = self.role_manager.dao.get_default_privileges(group_name, "r")
+            data = self.role_manager.dao.get_default_privileges(objtype="r")
         except Exception:
             data = {}
         finally:
@@ -169,7 +169,7 @@ class GroupsController(QObject):
                 code_map = {"tables": "r", "sequences": "S", "functions": "f", "types": "T"}
                 code = code_map.get(obj_type, "r")
                 try:
-                    self.role_manager.dao.get_default_privileges(group_name, code)
+                    self.role_manager.dao.get_default_privileges(owner=owner, objtype=code)
                 except Exception:
                     pass
                 if emit_signal:

--- a/tests/test_db_manager_default_privileges.py
+++ b/tests/test_db_manager_default_privileges.py
@@ -62,7 +62,7 @@ class DBManagerDefaultPrivTests(unittest.TestCase):
         self.assertIn("SELECT", executed[1])
 
     def test_alter_default_privileges_noop(self):
-        def fake_get_default_privileges(role, code):
+        def fake_get_default_privileges(owner=None, objtype="r", schema=None):
             return {"public": {"grp": {"SELECT"}}}
 
         self.dbm.get_default_privileges = fake_get_default_privileges


### PR DESCRIPTION
## Summary
- load default privileges directly from pg_default_acl and parse ACLs by grantee
- scope queries by future owner and optional schema when checking defaults
- adjust groups controller and tests for new default privilege behavior

## Testing
- `pytest tests/test_default_privileges.py tests/test_db_manager_default_privileges.py`
- `pytest` *(fails: connection to server at "localhost" failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689f39b09e2c832eb6feee07bd350f95