### PR TITLE
Add permission contract schema and filter managed roles

### DIFF
--- a/contracts/permission_contract.py
+++ b/contracts/permission_contract.py
@@ -1,0 +1,76 @@
+"""Permission contract schema and helpers (v1.4.3).
+
+Defines JSON schema for permission contract and validation utilities. The
+contract includes a list of regular expression patterns describing which
+principals (roles) are managed by the application.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+import json
+import re
+
+from jsonschema import Draft7Validator
+
+SCHEMA_VERSION = "1.4.3"
+
+PERMISSION_CONTRACT_SCHEMA: dict[str, Any] = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Permission Contract",
+    "type": "object",
+    "properties": {
+        "version": {"type": "string", "const": SCHEMA_VERSION},
+        "managed_principals": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "minItems": 1,
+        },
+    },
+    "required": ["version", "managed_principals"],
+    "additionalProperties": False,
+}
+
+
+def validate_contract(data: dict[str, Any]) -> dict[str, Any]:
+    """Validate *data* against :data:`PERMISSION_CONTRACT_SCHEMA`.
+
+    Raises ``jsonschema.ValidationError`` if invalid and returns the validated
+    data when successful.
+    """
+
+    Draft7Validator(PERMISSION_CONTRACT_SCHEMA).validate(data)
+    return data
+
+
+def load_contract(path: str | Path) -> dict[str, Any]:
+    """Load and validate a permission contract JSON file."""
+
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    return validate_contract(data)
+
+
+# Default contract used by the application. It is validated on import to ensure
+# the schema remains consistent.
+DEFAULT_CONTRACT = validate_contract(
+    {
+        "version": SCHEMA_VERSION,
+        # Application-managed role name patterns
+        "managed_principals": [r"^grp_[A-Za-z0-9_]+$", r"^usr_[A-Za-z0-9_]+$"],
+    }
+)
+
+_MANAGED_PATTERNS = [re.compile(p) for p in DEFAULT_CONTRACT["managed_principals"]]
+
+
+def is_managed_principal(name: str) -> bool:
+    """Return ``True`` if *name* matches any managed principal pattern."""
+
+    return any(pat.match(name) for pat in _MANAGED_PATTERNS)
+
+
+def filter_managed(names: Iterable[str]) -> list[str]:
+    """Filter *names* keeping only managed principals."""
+
+    return [n for n in names if is_managed_principal(n)]

--- a/gerenciador_postgres/db_manager.py
+++ b/gerenciador_postgres/db_manager.py
@@ -7,6 +7,8 @@ from typing import Optional, List, Dict, Set, Callable
 import logging
 import re
 
+from contracts.permission_contract import filter_managed
+
 logger = logging.getLogger(__name__)
 logger.propagate = True
 
@@ -162,7 +164,7 @@ class DBManager:
                   AND rolname <> 'postgres'
                 ORDER BY rolname
             """)
-            return [row[0] for row in cur.fetchall()]
+            return filter_managed([row[0] for row in cur.fetchall()])
 
     def create_group(self, group_name: str):
         with self.conn.cursor() as cur:
@@ -267,7 +269,7 @@ class DBManager:
                 WHERE u.rolname = %s
                 ORDER BY g.rolname
             """, (username,))
-            return [row[0] for row in cur.fetchall()]
+            return filter_managed([row[0] for row in cur.fetchall()])
 
     def list_groups(self) -> List[str]:
         with self.conn.cursor() as cur:
@@ -279,7 +281,7 @@ class DBManager:
                   AND rolname <> 'postgres'
                 ORDER BY rolname
             """)
-            return [row[0] for row in cur.fetchall()]
+            return filter_managed([row[0] for row in cur.fetchall()])
 
     def list_roles(self) -> List[str]:
         """Retorna todos os roles disponíveis (usuários e grupos)."""
@@ -292,7 +294,7 @@ class DBManager:
                 ORDER BY rolname
                 """
             )
-            return [row[0] for row in cur.fetchall()]
+            return filter_managed([row[0] for row in cur.fetchall()])
 
     # Métodos de tabelas e privilégios ------------------------------------
 

--- a/gerenciador_postgres/role_manager.py
+++ b/gerenciador_postgres/role_manager.py
@@ -118,16 +118,13 @@ class RoleManager:
             last = partes[-1].lower() if len(partes) > 1 else ""
             tentativa = 0
             while True:
-                # Novo padrão: sempre usar first.last (se existir sobrenome) como base inicial.
-                if last:
-                    base = f"{first}.{last}"
-                else:
-                    base = first
                 if tentativa == 0:
-                    candidate = base
+                    candidate = first
+                elif tentativa == 1 and last:
+                    candidate = f"{first}.{last}"
                 else:
-                    # Sufixos numéricos iniciam em 2 (first.last2)
-                    candidate = f"{base}{tentativa+1}"
+                    base = f"{first}.{last}" if last else first
+                    candidate = f"{base}{tentativa if last else tentativa+1}"
                 username = self._sanitize_username(candidate)
                 # Checagem prévia para evitar exceção de duplicidade e acelerar a próxima tentativa
                 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ PyYAML
 keyring
 python-dotenv
 pdfplumber
+jsonschema


### PR DESCRIPTION
## Summary
- add JSON schema-based permission contract module with managed_principals validation
- filter role listing queries to only return principals matching managed patterns
- refine batch username generation to try first name before adding surname

## Testing
- `pytest` *(fails: psycopg2.OperationalError: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689fb3b83718832eb1be24ce0c8eaf8a