### PR TITLE
feat: granular group privilege updates

### DIFF
--- a/tests/test_apply_group_privileges_diff.py
+++ b/tests/test_apply_group_privileges_diff.py
@@ -1,0 +1,75 @@
+import unittest
+from gerenciador_postgres.db_manager import DBManager
+
+
+class DummyCursor:
+    def __init__(self, current_privs, record=False):
+        self.current_privs = current_privs
+        self.record = record
+        self.executed = []
+        self.result = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql_query, params=None):
+        query = str(sql_query)
+        if "information_schema.role_table_grants" in query:
+            self.result = [
+                (schema, table, priv)
+                for schema, objs in self.current_privs.items()
+                for table, privs in objs.items()
+                for priv in privs
+            ]
+        elif self.record:
+            self.executed.append(query)
+
+    def fetchall(self):
+        return self.result
+
+
+class DummyConn:
+    def __init__(self, current_privs):
+        self.current_privs = current_privs
+        self.calls = 0
+        self.last_cursor = None
+
+    def cursor(self):
+        self.calls += 1
+        record = self.calls > 1
+        cur = DummyCursor(self.current_privs, record)
+        self.last_cursor = cur
+        return cur
+
+
+class ApplyGroupPrivilegesDiffTests(unittest.TestCase):
+    def test_grant_only(self):
+        conn = DummyConn({})
+        dbm = DBManager(conn)
+        dbm.apply_group_privileges("grp", {"public": {"t1": {"SELECT"}}})
+        commands = conn.last_cursor.executed
+        self.assertEqual(len(commands), 1)
+        self.assertIn("GRANT", commands[0])
+        self.assertNotIn("REVOKE", commands[0])
+
+    def test_revoke_only(self):
+        conn = DummyConn({"public": {"t1": {"SELECT"}}})
+        dbm = DBManager(conn)
+        dbm.apply_group_privileges("grp", {"public": {"t1": set()}})
+        commands = conn.last_cursor.executed
+        self.assertEqual(len(commands), 1)
+        self.assertIn("REVOKE", commands[0])
+        self.assertNotIn("GRANT", commands[0])
+
+    def test_no_change(self):
+        conn = DummyConn({"public": {"t1": {"SELECT"}}})
+        dbm = DBManager(conn)
+        dbm.apply_group_privileges("grp", {"public": {"t1": {"SELECT"}}})
+        self.assertEqual(conn.last_cursor.executed, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_privilege_whitelist.py
+++ b/tests/test_privilege_whitelist.py
@@ -13,6 +13,9 @@ class DummyCursor:
     def execute(self, sql, params=None):
         pass
 
+    def fetchall(self):
+        return []
+
 
 class DummyConn:
     def cursor(self):


### PR DESCRIPTION
## Summary
- avoid blanket REVOKE in group privilege application
- add tests for grant-only, revoke-only and no-change scenarios

## Testing
- `pytest -m "not integration"`

------
https://chatgpt.com/codex/tasks/task_e_689fb73a4ca4832e82d8312aa0e41900