### PR TITLE
Warn on privilege revocation with dependent objects

### DIFF
--- a/gerenciador_postgres/controllers/groups_controller.py
+++ b/gerenciador_postgres/controllers/groups_controller.py
@@ -90,12 +90,14 @@ class GroupsController(QObject):
         obj_type: str = "TABLE",
         defaults_applied: bool = False,
         emit_signal: bool = True,
+        check_dependencies: bool = True,
     ):
         success = self.role_manager.set_group_privileges(
             group_name,
             privileges,
             obj_type=obj_type,
             defaults_applied=defaults_applied,
+            check_dependencies=check_dependencies,
         )
         if success and emit_signal:
             self.data_changed.emit()

--- a/gerenciador_postgres/db_manager.py
+++ b/gerenciador_postgres/db_manager.py
@@ -358,6 +358,7 @@ class DBManager:
         group: str,
         privileges: Dict[str, Dict[str, Set[str]]],
         obj_type: str = "TABLE",
+        check_dependencies: bool = True,
     ):
         """Aplica GRANT/REVOKE para tabelas ou sequências.
 
@@ -396,6 +397,12 @@ class DBManager:
                     to_revoke = existing - desired
 
                     if to_revoke:
+                        if check_dependencies:
+                            deps = self.get_object_dependencies(schema, name)
+                            if deps:
+                                raise RuntimeError(
+                                    f"[WARN-DEPEND] {schema}.{name} possui dependências: {deps}"
+                                )
                         cur.execute(
                             sql.SQL("REVOKE {} ON {} {} FROM {}").format(
                                 sql.SQL(", ").join(sql.SQL(p) for p in sorted(to_revoke)),

--- a/gerenciador_postgres/role_manager.py
+++ b/gerenciador_postgres/role_manager.py
@@ -510,6 +510,7 @@ class RoleManager:
         privileges: Dict[str, Dict[str, Set[str]]],
         obj_type: str = "TABLE",
         defaults_applied: bool = False,
+        check_dependencies: bool = True,
     ) -> bool:
         try:
             with self.dao.transaction():
@@ -529,7 +530,12 @@ class RoleManager:
 
                 # Aplica privilégios reais (tabelas/sequências existentes)
                 if real_privs:
-                    self.dao.apply_group_privileges(group_name, real_privs, obj_type=obj_type)
+                    self.dao.apply_group_privileges(
+                        group_name,
+                        real_privs,
+                        obj_type=obj_type,
+                        check_dependencies=check_dependencies,
+                    )
 
                 # Ajusta default privileges para futuros objetos conforme FUTURE explícito
                 if obj_type_upper == 'TABLE':

--- a/tests/integration/test_dependency_warning.py
+++ b/tests/integration/test_dependency_warning.py
@@ -1,0 +1,68 @@
+import os
+import sys
+import pathlib
+
+import pytest
+import psycopg2
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from gerenciador_postgres.db_manager import DBManager
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def conn():
+    conn = psycopg2.connect(
+        host=os.getenv("PGHOST", "localhost"),
+        port=os.getenv("PGPORT", "5432"),
+        dbname=os.getenv("PGDATABASE", "postgres"),
+        user=os.getenv("PGUSER", "postgres"),
+        password=os.getenv("PGPASSWORD", "postgres"),
+    )
+    yield conn
+    conn.close()
+
+
+def test_revoke_warns_on_dependencies(conn):
+    db = DBManager(conn)
+    cur = conn.cursor()
+    cur.execute("DROP VIEW IF EXISTS public.dep_view")
+    cur.execute("DROP TABLE IF EXISTS public.dep_base CASCADE")
+    cur.execute("DROP ROLE IF EXISTS dep_role")
+    cur.execute("CREATE ROLE dep_role NOLOGIN")
+    cur.execute("CREATE TABLE public.dep_base(id int)")
+    cur.execute("CREATE VIEW public.dep_view AS SELECT * FROM public.dep_base")
+    cur.execute("GRANT SELECT ON public.dep_base TO dep_role")
+    conn.commit()
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            with db.transaction():
+                db.apply_group_privileges(
+                    "dep_role",
+                    {"public": {"dep_base": set()}},
+                    check_dependencies=True,
+                )
+        assert "[WARN-DEPEND]" in str(excinfo.value)
+        conn.rollback()
+
+        with db.transaction():
+            db.apply_group_privileges(
+                "dep_role",
+                {"public": {"dep_base": set()}},
+                check_dependencies=False,
+            )
+        cur.execute(
+            """
+            SELECT privilege_type
+            FROM information_schema.role_table_grants
+            WHERE grantee='dep_role' AND table_name='dep_base'
+            """
+        )
+        assert cur.fetchone() is None
+    finally:
+        cur.execute("DROP VIEW IF EXISTS public.dep_view")
+        cur.execute("DROP TABLE IF EXISTS public.dep_base")
+        cur.execute("DROP ROLE IF EXISTS dep_role")
+        conn.commit()

--- a/tests/test_role_manager_defaults.py
+++ b/tests/test_role_manager_defaults.py
@@ -10,7 +10,7 @@ class DummyDAO:
         self.conn = DummyConn()
         self.default_privs = []
 
-    def apply_group_privileges(self, group, privileges, obj_type="TABLE"):
+    def apply_group_privileges(self, group, privileges, obj_type="TABLE", check_dependencies=True):
         pass
 
     def alter_default_privileges(self, group, schema, obj_type, privileges):

--- a/tests/test_role_manager_templates.py
+++ b/tests/test_role_manager_templates.py
@@ -15,7 +15,7 @@ class DummyDAO:
     def list_tables_by_schema(self, **kwargs):
         return {"public": ["t1", "t2"]}
 
-    def apply_group_privileges(self, group, privileges, obj_type="TABLE"):
+    def apply_group_privileges(self, group, privileges, obj_type="TABLE", check_dependencies=True):
         self.applied = (group, privileges, obj_type)
 
     def grant_database_privileges(self, group, privileges):


### PR DESCRIPTION
## Summary
- check object dependencies before issuing REVOKE statements
- propagate dependency confirmation flag through role and group managers
- add integration test ensuring dependency warning when view depends on table

## Testing
- `pytest` *(failed: psycopg2.OperationalError: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689fb9703570832e81f405f148281bb1