### PR TITLE
Validate schema USAGE for object privilege grantees

### DIFF
--- a/tests/test_contract_usage.py
+++ b/tests/test_contract_usage.py
@@ -1,0 +1,28 @@
+import pytest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from contracts.permission_contract import validate_contract, SCHEMA_VERSION
+
+
+def test_object_privileges_require_usage():
+    contract = {
+        "version": SCHEMA_VERSION,
+        "managed_principals": ["grp_role"],
+        "schema_privileges": {"grp_role": {"public": ["CREATE"]}},
+        "object_privileges": {"grp_role": {"public": {"t1": ["SELECT"]}}},
+    }
+    with pytest.raises(ValueError):
+        validate_contract(contract)
+
+
+def test_object_privileges_with_usage_ok():
+    contract = {
+        "version": SCHEMA_VERSION,
+        "managed_principals": ["grp_role"],
+        "schema_privileges": {"grp_role": {"public": ["USAGE"]}},
+        "object_privileges": {"grp_role": {"public": {"t1": ["SELECT"]}}},
+    }
+    assert validate_contract(contract) == contract


### PR DESCRIPTION
## Summary
- extend permission contract schema to include schema/object privileges
- validate that grantees with object privileges also have USAGE on those schemas
- add tests for contract validation

## Testing
- `PYTHONPATH=. pytest tests/test_contract_usage.py -q`
- `PYTHONPATH=. pytest tests/test_privilege_whitelist.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689fbbd15c50832e924f5923e5d87234