### PR TITLE
feat: update permission contract schema to v1.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,23 @@ Após salvar permissões de schemas, tabelas ou padrões futuros, o sistema **n�
 - Na interface gráfica, utilize o botão **"Sincronizar (Full Sweep)"** disponível nas telas de grupos e de privilégios.
 - Pela linha de comando, execute `scripts/sweep_privileges.py --profile <perfil> [--group <grupo>]` para sincronizar todos os grupos ou apenas o grupo informado.
 
+## Contrato de Permissões
+
+A aplicação suporta definição de contratos de permissões no formato JSON para gerenciar papéis e privilégios no banco de dados.
+A versão atual do contrato é **1.4.4** e introduz os campos `contract_version`, `scope`, `managed_principals_mode`, `auto_onboard_creators` e `default_privileges`.
+
+Exemplos de contratos podem ser encontrados no diretório [`contracts/`](contracts/), como
+[`example_contract_basic.json`](contracts/example_contract_basic.json) e
+[`example_contract_default_privileges.json`](contracts/example_contract_default_privileges.json).
+Esses arquivos demonstram a estrutura mínima e o uso de `default_privileges` com a chave `for_role`.
+
+Para validar um contrato programaticamente:
+
+```python
+from contracts.permission_contract import load_contract
+contract = load_contract("contracts/example_contract_basic.json")
+```
+
 ## Testes
 Os testes automatizados estão no diretório `tests/`. Execute-os com:
 ```bash

--- a/contracts/example_contract_basic.json
+++ b/contracts/example_contract_basic.json
@@ -1,0 +1,7 @@
+{
+  "contract_version": "1.4.4",
+  "scope": "database",
+  "managed_principals_mode": "regex",
+  "auto_onboard_creators": false,
+  "managed_principals": ["^grp_[A-Za-z0-9_]+$", "^usr_[A-Za-z0-9_]+$"]
+}

--- a/contracts/example_contract_default_privileges.json
+++ b/contracts/example_contract_default_privileges.json
@@ -1,0 +1,22 @@
+{
+  "contract_version": "1.4.4",
+  "scope": "database",
+  "managed_principals_mode": "regex",
+  "auto_onboard_creators": false,
+  "managed_principals": ["grp_role"],
+  "schema_privileges": {
+    "grp_role": {
+      "public": ["USAGE"]
+    }
+  },
+  "default_privileges": {
+    "grp_role": {
+      "public": {
+        "tables": {
+          "privileges": ["SELECT"],
+          "for_role": "owner_role"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_contract_usage.py
+++ b/tests/test_contract_usage.py
@@ -9,7 +9,7 @@ from contracts.permission_contract import validate_contract, SCHEMA_VERSION
 
 def test_object_privileges_require_usage():
     contract = {
-        "version": SCHEMA_VERSION,
+        "contract_version": SCHEMA_VERSION,
         "managed_principals": ["grp_role"],
         "schema_privileges": {"grp_role": {"public": ["CREATE"]}},
         "object_privileges": {"grp_role": {"public": {"t1": ["SELECT"]}}},
@@ -20,9 +20,59 @@ def test_object_privileges_require_usage():
 
 def test_object_privileges_with_usage_ok():
     contract = {
-        "version": SCHEMA_VERSION,
+        "contract_version": SCHEMA_VERSION,
         "managed_principals": ["grp_role"],
         "schema_privileges": {"grp_role": {"public": ["USAGE"]}},
         "object_privileges": {"grp_role": {"public": {"t1": ["SELECT"]}}},
     }
     assert validate_contract(contract) == contract
+
+
+def test_default_privileges_require_usage():
+    contract = {
+        "contract_version": SCHEMA_VERSION,
+        "managed_principals": ["grp_role"],
+        "schema_privileges": {"grp_role": {"public": ["CREATE"]}},
+        "default_privileges": {
+            "grp_role": {
+                "public": {
+                    "tables": {"privileges": ["SELECT"], "for_role": "owner"}
+                }
+            }
+        },
+    }
+    with pytest.raises(ValueError):
+        validate_contract(contract, pg_roles={"owner"})
+
+
+def test_default_privileges_for_role_must_exist():
+    contract = {
+        "contract_version": SCHEMA_VERSION,
+        "managed_principals": ["grp_role"],
+        "schema_privileges": {"grp_role": {"public": ["USAGE"]}},
+        "default_privileges": {
+            "grp_role": {
+                "public": {
+                    "tables": {"privileges": ["SELECT"], "for_role": "missing"}
+                }
+            }
+        },
+    }
+    with pytest.raises(ValueError):
+        validate_contract(contract, pg_roles={"owner"})
+
+
+def test_default_privileges_with_usage_and_role_ok():
+    contract = {
+        "contract_version": SCHEMA_VERSION,
+        "managed_principals": ["grp_role"],
+        "schema_privileges": {"grp_role": {"public": ["USAGE"]}},
+        "default_privileges": {
+            "grp_role": {
+                "public": {
+                    "tables": {"privileges": ["SELECT"], "for_role": "owner"}
+                }
+            }
+        },
+    }
+    assert validate_contract(contract, pg_roles={"owner"}) == contract


### PR DESCRIPTION
## Summary
- rename `version` to `contract_version` and extend permission contract with new fields
- validate `default_privileges` for USAGE and existing `for_role`
- document and provide JSON examples for the new contract version

## Testing
- `pytest tests/test_contract_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_689fc2ca517c832e8b7b85d0a0d15694