### PR TITLE
Atualiza prefixos de roles e contrato

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ O arquivo `config/config.yml` centraliza parâmetros do sistema. Nele é possív
 
 - `log_level`: nível de detalhamento dos logs.
 - `log_path`: caminho do arquivo de log (relativo a `BASE_DIR`).
-- `group_prefix`: prefixo obrigatório para nomes de grupos (padrão `"grp_"`).
+- `group_prefix`: prefixo obrigatório para nomes de grupos (padrão `"turma_"`).
 - `schema_creation_group`: nome do grupo autorizado a criar schemas (padrão `"Professores"`).
 - `connect_timeout`: tempo máximo (segundos) para tentar conectar ao banco (padrão `5`).
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -10,7 +10,8 @@ databases:
   name: Bettina_perfil
   port: 5432
   user: Bettina
-group_prefix: grp_
+group_prefix: turma_
+user_prefix: monitores_
 log_level: DEBUG
 log_path: D:\GitHub\IFSC_SGBD\logs\app.log
 schema_creation_group: Professores

--- a/contracts/example_contract_basic.json
+++ b/contracts/example_contract_basic.json
@@ -3,5 +3,5 @@
   "scope": "database",
   "managed_principals_mode": "regex",
   "auto_onboard_creators": false,
-  "managed_principals": ["^grp_[A-Za-z0-9_]+$", "^usr_[A-Za-z0-9_]+$"]
+  "managed_principals": ["^turma_[A-Za-z0-9_]+$", "^monitores_[A-Za-z0-9_]+$"]
 }

--- a/contracts/example_contract_default_privileges.json
+++ b/contracts/example_contract_default_privileges.json
@@ -3,14 +3,14 @@
   "scope": "database",
   "managed_principals_mode": "regex",
   "auto_onboard_creators": false,
-  "managed_principals": ["grp_role"],
+  "managed_principals": ["turma_role"],
   "schema_privileges": {
-    "grp_role": {
+    "turma_role": {
       "public": ["USAGE"]
     }
   },
   "default_privileges": {
-    "grp_role": {
+    "turma_role": {
       "public": {
         "tables": {
           "privileges": ["SELECT"],

--- a/contracts/permission_contract.py
+++ b/contracts/permission_contract.py
@@ -140,7 +140,7 @@ DEFAULT_CONTRACT = validate_contract(
         "managed_principals_mode": "regex",
         "auto_onboard_creators": False,
         # Application-managed role name patterns
-        "managed_principals": [r"^grp_[A-Za-z0-9_]+$", r"^usr_[A-Za-z0-9_]+$"],
+        "managed_principals": [r"^turma_[A-Za-z0-9_]+$", r"^monitores_[A-Za-z0-9_]+$"],
     }
 )
 

--- a/force_reload.py
+++ b/force_reload.py
@@ -38,12 +38,12 @@ def force_reload_and_test():
             
             # Testa com o grupo que estava dando erro
             print("\n🧪 Testando get_schema_privileges...")
-            result = db.get_schema_privileges('grp_Geo2_2025-2')
+            result = db.get_schema_privileges('turma_Geo2_2025-2')
             print(f"✅ Resultado: {result}")
             
             # Testa também default privileges
             print("\n🧪 Testando get_default_table_privileges...")
-            result2 = db.get_default_table_privileges('grp_Geo2_2025-2')
+            result2 = db.get_default_table_privileges('turma_Geo2_2025-2')
             print(f"✅ Resultado: {result2}")
             
         except Exception as e:

--- a/gerenciador_postgres/config_manager.py
+++ b/gerenciador_postgres/config_manager.py
@@ -17,7 +17,8 @@ else:
 DEFAULT_CONFIG = {
     "log_path": str(BASE_DIR / "logs" / "app.log"),
     "log_level": "INFO",
-    "group_prefix": "grp_",
+    "group_prefix": "turma_",
+    "user_prefix": "monitores_",
     "schema_creation_group": "Professores",
     "connect_timeout": 5,
 }

--- a/gerenciador_postgres/gui/groups_view.py
+++ b/gerenciador_postgres/gui/groups_view.py
@@ -205,15 +205,15 @@ class GroupsView(QWidget):
         name, ok = QInputDialog.getText(
             self,
             "Novo Grupo",
-            "Digite o nome do grupo (o prefixo 'grp_' será adicionado automaticamente):",
+            "Digite o nome do grupo (o prefixo 'turma_' será adicionado automaticamente):",
             QLineEdit.EchoMode.Normal,
             "",
         )
         if not ok or not name.strip():
             return
         name = name.strip().lower()
-        if not name.startswith("grp_"):
-            name = f"grp_{name}"
+        if not name.startswith("turma_"):
+            name = f"turma_{name}"
         try:
             self.controller.create_group(name)
             QMessageBox.information(self, "Sucesso", f"Grupo '{name}' criado.")

--- a/gerenciador_postgres/gui/students_view.py
+++ b/gerenciador_postgres/gui/students_view.py
@@ -72,15 +72,15 @@ class StudentsView(QWidget):
             group_name, ok = QInputDialog.getText(
                 self,
                 "Nova Turma",
-                "Digite o nome da turma (o prefixo 'grp_' será adicionado automaticamente):",
+                "Digite o nome da turma (o prefixo 'turma_' será adicionado automaticamente):",
                 QLineEdit.EchoMode.Normal,
                 "",
             )
             if not ok or not group_name.strip():
                 return None
             group_name = group_name.strip().lower()
-            if not group_name.startswith("grp_"):
-                group_name = f"grp_{group_name}"
+            if not group_name.startswith("turma_"):
+                group_name = f"turma_{group_name}"
             try:
                 self.controller.create_group(group_name)
                 self.controller.apply_template_to_group(group_name, DEFAULT_TEMPLATE)

--- a/gerenciador_postgres/gui/users_view.py
+++ b/gerenciador_postgres/gui/users_view.py
@@ -295,12 +295,12 @@ class BatchInsertDialog(QDialog):
         validade = self.date.date().toString('yyyy-MM-dd') if self.chkValidade.isChecked() else None
         grupo = self.cmbGrupo.currentText()
         if grupo == "-- Criar novo grupo --":
-            grupo, ok = QInputDialog.getText(self, "Novo Grupo", "Nome do grupo (prefixo grp_ será adicionado se faltar)")
+            grupo, ok = QInputDialog.getText(self, "Novo Grupo", "Nome do grupo (prefixo turma_ será adicionado se faltar)")
             if not ok or not grupo.strip():
                 raise ValueError("Grupo inválido")
             grupo = grupo.strip()
-            if not grupo.lower().startswith('grp_'):
-                grupo = 'grp_' + grupo.lower()
+            if not grupo.lower().startswith('turma_'):
+                grupo = 'turma_' + grupo.lower()
         return usuarios, validade, grupo
 
 

--- a/gerenciador_postgres/role_manager.py
+++ b/gerenciador_postgres/role_manager.py
@@ -303,8 +303,8 @@ class RoleManager:
     def create_group(self, group_name: str) -> str:
         try:
             config = load_config()
-            prefix = config.get("group_prefix", "grp_")
-            if not prefix.startswith("grp_"):
+            prefix = config.get("group_prefix", "turma_")
+            if not prefix.startswith("turma_"):
                 raise ValueError("Prefixo de grupo inválido")
             # Sanitiza e aplica prefixo automaticamente
             group_name = self._sanitize_group_name(group_name, prefix=prefix)
@@ -838,12 +838,12 @@ class RoleManager:
             if not group_name.startswith(prefix):
                 # Evita duplicar prefixo se usuário digitou algo parecido
                 if group_name.startswith(prefix.rstrip('_')):
-                    # ex: prefix=grp_ e name inicia com 'grp' sem underscore
+                    # ex: prefix=turma_ e name inicia com 'turma' sem underscore
                     group_name = group_name[len(prefix.rstrip('_')):]
                 group_name = f"{prefix}{group_name}" if not group_name.startswith(prefix) else group_name
         else:
             # fallback padrão
-            if not group_name.startswith('grp_'):
-                group_name = f"grp_{group_name}"
+            if not group_name.startswith('turma_'):
+                group_name = f"turma_{group_name}"
         group_name = self._truncate_identifier(group_name)
         return group_name

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -22,7 +22,8 @@ def test_load_config_creates_file(tmp_path, monkeypatch):
     assert config_file.exists()
     assert data["log_level"] == "INFO"
     assert "log_path" in data
-    assert data["group_prefix"] == "grp_"
+    assert data["group_prefix"] == "turma_"
+    assert data["user_prefix"] == "monitores_"
     assert data["schema_creation_group"] == "Professores"
     assert data["connect_timeout"] == 5
 

--- a/tests/test_role_manager_group_prefix.py
+++ b/tests/test_role_manager_group_prefix.py
@@ -45,15 +45,15 @@ class RoleManagerGroupPrefixTests(unittest.TestCase):
         self.rm = RoleManager(self.dao, logging.getLogger("test"))
 
     def test_create_group_respects_prefix(self):
-        with patch("gerenciador_postgres.role_manager.load_config", return_value={"group_prefix": "grp_"}):
-            created = self.rm.create_group("grp_valid")
-            self.assertEqual(created, "grp_valid")
-            self.assertIn("grp_valid", self.dao.groups)
+        with patch("gerenciador_postgres.role_manager.load_config", return_value={"group_prefix": "turma_"}):
+            created = self.rm.create_group("turma_valid")
+            self.assertEqual(created, "turma_valid")
+            self.assertIn("turma_valid", self.dao.groups)
 
     def test_create_group_invalid_prefix(self):
         with patch("gerenciador_postgres.role_manager.load_config", return_value={"group_prefix": "class_"}):
             with self.assertRaises(ValueError):
-                self.rm.create_group("grp_invalid")
+                self.rm.create_group("turma_invalid")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- define prefixos `turma_` e `monitores_` no arquivo de configuração e no config manager
- ajusta contrato de permissões para os novos padrões
- adapta RoleManager e interfaces para o prefixo `turma_`

## Testing
- `pytest` *(falhou: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689fc4d459bc832eb50c5f255c9a5419