### PR TITLE
Add PostgreSQL privilege reconciliation helpers

### DIFF
--- a/gerenciador_postgres/__init__.py
+++ b/gerenciador_postgres/__init__.py
@@ -1,1 +1,5 @@
-# Pacote principal do Gerenciador PostgreSQL
+"""Gerenciador PostgreSQL core package."""
+
+from . import state_reader, reconciler, executor
+
+__all__ = ["state_reader", "reconciler", "executor"]

--- a/gerenciador_postgres/executor.py
+++ b/gerenciador_postgres/executor.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+"""Apply privilege diff operations to a PostgreSQL database."""
+
+from typing import Iterable, List, Mapping
+import time
+
+from psycopg2 import OperationalError, sql
+from psycopg2.extensions import connection
+
+LOCK_CODES = {"55P03"}  # lock_not_available
+
+
+class Executor:
+    """Execute GRANT/REVOKE operations within a single transaction.
+
+    Parameters
+    ----------
+    conn:
+        psycopg2 connection used to execute operations.
+    max_retries:
+        Number of retries when ``lock_not_available`` errors are raised.
+    retry_interval:
+        Seconds to wait between retries.
+    """
+
+    def __init__(self, conn: connection, max_retries: int = 3, retry_interval: float = 0.5):
+        self.conn = conn
+        self.max_retries = max_retries
+        self.retry_interval = retry_interval
+
+    # ------------------------------------------------------------------
+    def apply(self, operations: Iterable[Mapping[str, object]]):
+        ops = list(operations)
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                with self.conn:  # transaction context
+                    with self.conn.cursor() as cur:
+                        for op in ops:
+                            self._execute_op(cur, op)
+                break
+            except OperationalError as e:  # pragma: no cover - hard to trigger
+                if getattr(e, "pgcode", None) in LOCK_CODES and attempt < self.max_retries:
+                    time.sleep(self.retry_interval)
+                    continue
+                raise
+
+    # ------------------------------------------------------------------
+    def _execute_op(self, cur, op: Mapping[str, object]):
+        action = op["action"].upper()
+        target = op["target"]
+        privileges = op.get("privileges", [])
+        grantee = sql.Identifier(op["grantee"])
+
+        if target == "SCHEMA":
+            identifier = sql.Identifier(op["schema"])
+            priv_part = (
+                sql.SQL(", ").join(sql.SQL(p) for p in privileges)
+                if privileges
+                else sql.SQL("ALL PRIVILEGES")
+            )
+            query = sql.SQL("{} {} ON SCHEMA {} {} {}" ).format(
+                sql.SQL(action),
+                priv_part if action == "GRANT" else priv_part,
+                identifier,
+                sql.SQL("TO") if action == "GRANT" else sql.SQL("FROM"),
+                grantee,
+            )
+            cur.execute(query)
+            return
+
+        identifier = sql.Identifier(op["schema"], op["object"])
+        keyword = sql.SQL(target)
+        priv_part = (
+            sql.SQL(", ").join(sql.SQL(p) for p in privileges)
+            if privileges
+            else sql.SQL("ALL PRIVILEGES")
+        )
+        query = sql.SQL("{} {} ON {} {} {} {}" ).format(
+            sql.SQL(action),
+            priv_part,
+            keyword,
+            identifier,
+            sql.SQL("TO") if action == "GRANT" else sql.SQL("FROM"),
+            grantee,
+        )
+        cur.execute(query)
+

--- a/gerenciador_postgres/reconciler.py
+++ b/gerenciador_postgres/reconciler.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+"""Generate differences between current database state and a permission contract."""
+
+from typing import Dict, Iterable, List, Set
+
+from psycopg2.extensions import connection
+
+from . import state_reader
+
+# Mapping from pg_class.relkind to keywords used in GRANT/REVOKE statements
+OBJTYPE_KEYWORDS = {
+    "r": "TABLE",  # ordinary table
+    "v": "TABLE",  # view
+    "m": "TABLE",  # materialized view
+    "S": "SEQUENCE",
+}
+
+
+class Reconciler:
+    """Compute privilege operations required to satisfy a contract.
+
+    The diff is returned as a list of operation dictionaries.  Each operation
+    contains the following keys depending on the target level::
+
+        {'action': 'grant'|'revoke', 'target': 'SCHEMA',
+         'schema': str, 'grantee': str, 'privileges': List[str]}
+
+        {'action': 'grant'|'revoke', 'target': 'TABLE'|'SEQUENCE',
+         'schema': str, 'object': str, 'grantee': str, 'privileges': List[str]}
+    """
+
+    def __init__(self, conn: connection):
+        self.conn = conn
+
+    # ------------------------------------------------------------------
+    def diff(self, contract: Dict[str, dict]) -> List[dict]:
+        ops: List[dict] = []
+        schema_privs = contract.get("schema_privileges", {})
+        object_privs = contract.get("object_privileges", {})
+
+        roles = set(schema_privs) | set(object_privs)
+
+        for role in sorted(roles):
+            desired_schema = {
+                schema: set(map(str.upper, privs))
+                for schema, privs in schema_privs.get(role, {}).items()
+            }
+            current_schema = state_reader.get_schema_privileges(self.conn, role)
+            all_schemas = set(desired_schema) | set(current_schema)
+            for schema in sorted(all_schemas):
+                desired = desired_schema.get(schema, set())
+                current = current_schema.get(schema, set())
+                to_grant = desired - current
+                to_revoke = current - desired
+                if to_revoke:
+                    ops.append(
+                        {
+                            "action": "revoke",
+                            "target": "SCHEMA",
+                            "schema": schema,
+                            "grantee": role,
+                            "privileges": sorted(to_revoke),
+                        }
+                    )
+                if to_grant:
+                    ops.append(
+                        {
+                            "action": "grant",
+                            "target": "SCHEMA",
+                            "schema": schema,
+                            "grantee": role,
+                            "privileges": sorted(to_grant),
+                        }
+                    )
+
+            desired_objs = object_privs.get(role, {})
+            for schema, objects in desired_objs.items():
+                objtypes = state_reader.get_objects(self.conn, schema)
+                for obj, privs in objects.items():
+                    desired_set = set(map(str.upper, privs))
+                    kind = objtypes.get(obj)
+                    keyword = OBJTYPE_KEYWORDS.get(kind, "TABLE")
+                    current_acls = state_reader.get_object_acls(
+                        self.conn, schema, obj
+                    )
+                    current_set = current_acls.get(role, set())
+                    to_grant = desired_set - current_set
+                    to_revoke = current_set - desired_set
+                    if to_revoke:
+                        ops.append(
+                            {
+                                "action": "revoke",
+                                "target": keyword,
+                                "schema": schema,
+                                "object": obj,
+                                "grantee": role,
+                                "privileges": sorted(to_revoke),
+                            }
+                        )
+                    if to_grant:
+                        ops.append(
+                            {
+                                "action": "grant",
+                                "target": keyword,
+                                "schema": schema,
+                                "object": obj,
+                                "grantee": role,
+                                "privileges": sorted(to_grant),
+                            }
+                        )
+        return ops
+

--- a/gerenciador_postgres/state_reader.py
+++ b/gerenciador_postgres/state_reader.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+"""Utilities to read PostgreSQL current privilege state.
+
+This module provides small helper functions that query the database and
+return information about roles, schema privileges, object privileges and
+other metadata required by the reconciliation process.  The functions are
+intentionally lightweight and depend only on a DB-API compatible
+connection object (``psycopg2`` connection in practice).
+
+The implementations mirror the behaviour previously found on
+``DBManager`` methods but are exposed as stand alone helpers so they can be
+used without the higher level manager classes.
+"""
+
+from typing import Dict, Iterable, List, Set, Tuple
+
+from psycopg2.extensions import connection
+from psycopg2 import sql
+
+from .db_manager import DBManager
+
+# ---------------------------------------------------------------------------
+# Generic helpers
+
+
+def list_roles(conn: connection) -> List[str]:
+    """Return list of roles in the cluster excluding built-in ones."""
+    query = (
+        "SELECT rolname FROM pg_roles "
+        "WHERE rolname NOT LIKE 'pg\\_%' AND rolname <> 'postgres' "
+        "ORDER BY rolname"
+    )
+    with conn.cursor() as cur:
+        cur.execute(query)
+        return [row[0] for row in cur.fetchall()]
+
+
+# ---------------------------------------------------------------------------
+# Schema privileges
+
+
+def get_schema_privileges(conn: connection, role: str) -> Dict[str, Set[str]]:
+    """Return schema privileges for *role*.
+
+    The function delegates to :class:`DBManager` implementation to keep the
+    same behaviour, including resilience against malformed rows returned by
+    some adapters (see regression tests).
+    """
+
+    dbm = DBManager(conn)
+    return dbm.get_schema_privileges(role)
+
+
+# ---------------------------------------------------------------------------
+# Object inspection helpers
+
+
+def get_objects(
+    conn: connection, schema: str, kinds: Iterable[str] | None = None
+) -> Dict[str, str]:
+    """Return mapping of object name -> ``relkind`` for objects in *schema*.
+
+    ``kinds`` may be an iterable of PostgreSQL ``relkind`` codes.  When
+    omitted the function returns tables, views and sequences.
+    """
+
+    if kinds is None:
+        kinds = ["r", "v", "m", "S"]  # tables, views, matviews, sequences
+    query = sql.SQL(
+        """
+        SELECT c.relname, c.relkind
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = %s AND c.relkind = ANY(%s)
+        """
+    )
+    with conn.cursor() as cur:
+        cur.execute(query, (schema, list(kinds)))
+        rows = cur.fetchall()
+    return {row[0]: row[1] for row in rows}
+
+
+def get_object_acls(
+    conn: connection, schema: str, objname: str
+) -> Dict[str, Set[str]]:
+    """Return privileges for *objname* within *schema* grouped by grantee."""
+
+    query = sql.SQL(
+        """
+        SELECT grantee, privilege_type
+        FROM information_schema.role_table_grants
+        WHERE table_schema = %s AND table_name = %s
+        UNION ALL
+        SELECT grantee, privilege_type
+        FROM information_schema.role_usage_grants
+        WHERE object_schema = %s AND object_name = %s
+        """
+    )
+    with conn.cursor() as cur:
+        cur.execute(query, (schema, objname, schema, objname))
+        result: Dict[str, Set[str]] = {}
+        for grantee, priv in cur.fetchall():
+            result.setdefault(grantee, set()).add(priv)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Default privileges and dependencies
+
+
+def get_default_privileges(
+    conn: connection,
+    owner: str | None = None,
+    objtype: str = "r",
+    schema: str | None = None,
+) -> Dict[str, Dict[str, Set[str]]]:
+    """Expose :func:`DBManager.get_default_privileges` as a standalone helper."""
+
+    dbm = DBManager(conn)
+    return dbm.get_default_privileges(owner=owner, objtype=objtype, schema=schema)
+
+
+def get_dependencies(
+    conn: connection, schema: str, objname: str
+) -> List[Tuple[str, str]]:
+    """Return dependent objects for *schema.objname*.
+
+    Delegates to :meth:`DBManager.get_object_dependencies` for robustness.
+    """
+
+    dbm = DBManager(conn)
+    return dbm.get_object_dependencies(schema, objname)
+

--- a/tests/integration/test_reconciler_executor.py
+++ b/tests/integration/test_reconciler_executor.py
@@ -1,0 +1,94 @@
+import os
+import pathlib
+import sys
+
+import psycopg2
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from gerenciador_postgres import executor, reconciler
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def conn():
+    try:
+        conn = psycopg2.connect(
+            host=os.getenv("PGHOST", "localhost"),
+            port=os.getenv("PGPORT", "5432"),
+            dbname=os.getenv("PGDATABASE", "postgres"),
+            user=os.getenv("PGUSER", "postgres"),
+            password=os.getenv("PGPASSWORD", "postgres"),
+        )
+    except psycopg2.OperationalError as e:  # pragma: no cover - depends on env
+        pytest.skip(f"PostgreSQL not available: {e}")
+    yield conn
+    conn.close()
+
+
+def _cleanup(cur):
+    cur.execute("DROP TABLE IF EXISTS public.recon_t")
+    cur.execute("DROP ROLE IF EXISTS recon_role")
+
+
+def test_reconcile_apply_roundtrip(conn):
+    cur = conn.cursor()
+    _cleanup(cur)
+    cur.execute("CREATE ROLE recon_role NOLOGIN")
+    cur.execute("CREATE TABLE public.recon_t(id serial primary key)")
+    conn.commit()
+    try:
+        contract = {
+            "schema_privileges": {"recon_role": {"public": ["USAGE"]}},
+            "object_privileges": {
+                "recon_role": {"public": {"recon_t": ["SELECT"]}}
+            },
+        }
+        rec = reconciler.Reconciler(conn)
+        ops = rec.diff(contract)
+        execu = executor.Executor(conn)
+        execu.apply(ops)
+
+        cur.execute(
+            """
+            SELECT privilege_type FROM information_schema.schema_privileges
+            WHERE grantee='recon_role' AND schema_name='public'
+            """
+        )
+        assert {row[0] for row in cur.fetchall()} == {"USAGE"}
+        cur.execute(
+            """
+            SELECT privilege_type FROM information_schema.role_table_grants
+            WHERE grantee='recon_role' AND table_name='recon_t'
+            """
+        )
+        assert {row[0] for row in cur.fetchall()} == {"SELECT"}
+
+        # now revoke via new contract
+        contract2 = {
+            "schema_privileges": {"recon_role": {"public": []}},
+            "object_privileges": {
+                "recon_role": {"public": {"recon_t": []}}
+            },
+        }
+        ops2 = rec.diff(contract2)
+        execu.apply(ops2)
+        cur.execute(
+            """
+            SELECT privilege_type FROM information_schema.schema_privileges
+            WHERE grantee='recon_role' AND schema_name='public'
+            """
+        )
+        assert cur.fetchone() is None
+        cur.execute(
+            """
+            SELECT privilege_type FROM information_schema.role_table_grants
+            WHERE grantee='recon_role' AND table_name='recon_t'
+            """
+        )
+        assert cur.fetchone() is None
+    finally:
+        _cleanup(cur)
+        conn.commit()

--- a/tests/test_state_reader.py
+++ b/tests/test_state_reader.py
@@ -1,0 +1,130 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from gerenciador_postgres import state_reader
+
+
+class DummyCursor:
+    def __init__(self):
+        self.result = [("public", "USAGE"), ("broken",), None]
+        self.fetchone_values = [(True,), (False,), (False,), (False,)]
+        self.idx = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql, params=None):
+        pass
+
+    def fetchall(self):
+        return self.result
+
+    def fetchone(self):
+        val = self.fetchone_values[self.idx]
+        self.idx += 1
+        return val
+
+
+class DummyConn:
+    def cursor(self):
+        return DummyCursor()
+
+
+def test_get_schema_privileges_handles_short_rows():
+    conn = DummyConn()
+    privs = state_reader.get_schema_privileges(conn, "grp")
+    assert privs == {"public": {"USAGE"}}
+
+
+class DummyCursorDeps:
+    def __init__(self):
+        self.executed = []
+        self.result = [
+            ("public", "view1"),
+            ("other", "view2"),
+            ("broken",),
+            None,
+        ]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+
+    def fetchall(self):
+        return self.result
+
+
+class DummyConnDeps:
+    def __init__(self):
+        self.cursors = []
+
+    def cursor(self):
+        cur = DummyCursorDeps()
+        self.cursors.append(cur)
+        return cur
+
+
+def test_get_dependencies_filters_rows():
+    conn = DummyConnDeps()
+    deps = state_reader.get_dependencies(conn, "public", "tbl")
+    assert deps == [("public", "view1"), ("other", "view2")]
+    cur = conn.cursors[0]
+    assert cur.executed[0][1] == ("public", "tbl")
+
+
+class DummyCursorDefaults:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql, params=None):
+        self._sql = sql
+
+    def fetchall(self):
+        return self.rows
+
+
+class DummyConnDefaults:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def cursor(self):
+        return DummyCursorDefaults(self.rows)
+
+
+def test_get_default_privileges_parsing():
+    rows = [
+        ("postgres", "geo2", ['"grp_Geo2_2025-2"=arwd/postgres']),
+        ("postgres", "public", ['"grp_Geo2_2025-2"=r/postgres']),
+        ("postgres", "Teste_001_Esquema", ['"grp_Geo2_2025-2"=arw/postgres']),
+    ]
+    conn = DummyConnDefaults(rows)
+    res = state_reader.get_default_privileges(conn, owner="postgres")
+    assert res["geo2"]["grp_Geo2_2025-2"] == {
+        "DELETE",
+        "INSERT",
+        "SELECT",
+        "UPDATE",
+    }
+    assert res["public"]["grp_Geo2_2025-2"] == {"SELECT"}
+    assert res["Teste_001_Esquema"]["grp_Geo2_2025-2"] == {
+        "INSERT",
+        "SELECT",
+        "UPDATE",
+    }
+    assert res["_meta"]["owner_roles"]["geo2"] == "postgres"


### PR DESCRIPTION
## Summary
- add `state_reader` module to inspect roles, privileges and dependencies
- add `reconciler` to compute grant/revoke operations from contracts
- add transactional `executor` with retry handling
- include integration tests for reconciliation flow

## Testing
- `pytest tests/test_state_reader.py -q`
- `pytest tests/integration/test_reconciler_executor.py -q`
- `pytest -q` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689fcc027cb0832ea7e1252547e04b90