### PR TITLE
feat: expand permission contract schema

### DIFF
--- a/contracts/example_contract_basic.json
+++ b/contracts/example_contract_basic.json
@@ -1,6 +1,6 @@
 {
   "contract_version": "1.4.4",
-  "scope": "database",
+  "scope": {"database": "example", "schema": "public"},
   "managed_principals_mode": "regex",
   "auto_onboard_creators": false,
   "managed_principals": ["^turma_[A-Za-z0-9_]+$", "^monitores_[A-Za-z0-9_]+$"]

--- a/contracts/example_contract_default_privileges.json
+++ b/contracts/example_contract_default_privileges.json
@@ -1,6 +1,6 @@
 {
   "contract_version": "1.4.4",
-  "scope": "database",
+  "scope": {"database": "example", "schema": "public"},
   "managed_principals_mode": "regex",
   "auto_onboard_creators": false,
   "managed_principals": ["turma_role"],
@@ -9,14 +9,14 @@
       "public": ["USAGE"]
     }
   },
-  "default_privileges": {
-    "turma_role": {
-      "public": {
-        "tables": {
-          "privileges": ["SELECT"],
-          "for_role": "owner_role"
-        }
+  "default_privileges": [
+    {
+      "for_role": "owner_role",
+      "in_schema": "public",
+      "on": "tables",
+      "grants": {
+        "turma_role": ["SELECT"]
       }
     }
-  }
+  ]
 }

--- a/tests/test_contract_usage.py
+++ b/tests/test_contract_usage.py
@@ -33,13 +33,14 @@ def test_default_privileges_require_usage():
         "contract_version": SCHEMA_VERSION,
         "managed_principals": ["grp_role"],
         "schema_privileges": {"grp_role": {"public": ["CREATE"]}},
-        "default_privileges": {
-            "grp_role": {
-                "public": {
-                    "tables": {"privileges": ["SELECT"], "for_role": "owner"}
-                }
+        "default_privileges": [
+            {
+                "for_role": "owner",
+                "in_schema": "public",
+                "on": "tables",
+                "grants": {"grp_role": ["SELECT"]},
             }
-        },
+        ],
     }
     with pytest.raises(ValueError):
         validate_contract(contract, pg_roles={"owner"})
@@ -50,13 +51,14 @@ def test_default_privileges_for_role_must_exist():
         "contract_version": SCHEMA_VERSION,
         "managed_principals": ["grp_role"],
         "schema_privileges": {"grp_role": {"public": ["USAGE"]}},
-        "default_privileges": {
-            "grp_role": {
-                "public": {
-                    "tables": {"privileges": ["SELECT"], "for_role": "missing"}
-                }
+        "default_privileges": [
+            {
+                "for_role": "missing",
+                "in_schema": "public",
+                "on": "tables",
+                "grants": {"grp_role": ["SELECT"]},
             }
-        },
+        ],
     }
     with pytest.raises(ValueError):
         validate_contract(contract, pg_roles={"owner"})
@@ -67,12 +69,13 @@ def test_default_privileges_with_usage_and_role_ok():
         "contract_version": SCHEMA_VERSION,
         "managed_principals": ["grp_role"],
         "schema_privileges": {"grp_role": {"public": ["USAGE"]}},
-        "default_privileges": {
-            "grp_role": {
-                "public": {
-                    "tables": {"privileges": ["SELECT"], "for_role": "owner"}
-                }
+        "default_privileges": [
+            {
+                "for_role": "owner",
+                "in_schema": "public",
+                "on": "tables",
+                "grants": {"grp_role": ["SELECT"]},
             }
-        },
+        ],
     }
     assert validate_contract(contract, pg_roles={"owner"}) == contract


### PR DESCRIPTION
## Summary
- refine permission contract schema with explicit scope object and grant list format
- validate new default privilege entries and support conservative principal mode
- update example contracts and contract usage tests

## Testing
- `pytest tests/test_contract_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_689fd45c762c832eae6f6b5094d07316