### PR TITLE
Add default privileges reconciliation to Reconciler

### DIFF
--- a/tests/integration/test_reconciler_executor.py
+++ b/tests/integration/test_reconciler_executor.py
@@ -33,6 +33,13 @@ def _cleanup(cur):
     cur.execute("DROP ROLE IF EXISTS recon_role")
 
 
+def _cleanup_defaults(cur):
+    cur.execute("DROP TABLE IF EXISTS public.def_t1")
+    cur.execute("DROP TABLE IF EXISTS public.def_t2")
+    cur.execute("DROP ROLE IF EXISTS def_owner")
+    cur.execute("DROP ROLE IF EXISTS def_grantee")
+
+
 def test_reconcile_apply_roundtrip(conn):
     cur = conn.cursor()
     _cleanup(cur)
@@ -91,4 +98,64 @@ def test_reconcile_apply_roundtrip(conn):
         assert cur.fetchone() is None
     finally:
         _cleanup(cur)
+        conn.commit()
+
+
+def test_default_privileges_roundtrip(conn):
+    cur = conn.cursor()
+    _cleanup_defaults(cur)
+    cur.execute("CREATE ROLE def_owner LOGIN PASSWORD 'pw'")
+    cur.execute("CREATE ROLE def_grantee NOLOGIN")
+    cur.execute("GRANT USAGE ON SCHEMA public TO def_grantee")
+    cur.execute("GRANT USAGE, CREATE ON SCHEMA public TO def_owner")
+    conn.commit()
+    try:
+        contract = {
+            "schema_privileges": {"def_grantee": {"public": ["USAGE"]}},
+            "default_privileges": [
+                {
+                    "for_role": "def_owner",
+                    "in_schema": "public",
+                    "on": "tables",
+                    "grants": {"def_grantee": ["SELECT"]},
+                }
+            ],
+        }
+        rec = reconciler.Reconciler(conn)
+        ops = rec.diff(contract)
+        execu = executor.Executor(conn)
+        execu.apply(ops)
+
+        cur.execute("SET ROLE def_owner")
+        cur.execute("CREATE TABLE public.def_t1(id serial primary key)")
+        cur.execute("RESET ROLE")
+        conn.commit()
+        cur.execute(
+            """
+            SELECT privilege_type FROM information_schema.role_table_grants
+            WHERE grantee='def_grantee' AND table_name='def_t1'
+            """
+        )
+        assert {row[0] for row in cur.fetchall()} == {"SELECT"}
+
+        contract2 = {
+            "schema_privileges": {"def_grantee": {"public": ["USAGE"]}},
+            "default_privileges": [],
+        }
+        ops2 = rec.diff(contract2)
+        execu.apply(ops2)
+
+        cur.execute("SET ROLE def_owner")
+        cur.execute("CREATE TABLE public.def_t2(id serial primary key)")
+        cur.execute("RESET ROLE")
+        conn.commit()
+        cur.execute(
+            """
+            SELECT privilege_type FROM information_schema.role_table_grants
+            WHERE grantee='def_grantee' AND table_name='def_t2'
+            """
+        )
+        assert cur.fetchone() is None
+    finally:
+        _cleanup_defaults(cur)
         conn.commit()


### PR DESCRIPTION
## Summary
- detect differences in default privileges via `diff_default_privileges`
- support ALTER DEFAULT PRIVILEGES in executor
- add integration test for default privilege round-trip

## Testing
- `pytest` (fails: connection to server at "localhost" (::1), port 5432 failed)
- `pytest -k 'not integration'`


------
https://chatgpt.com/codex/tasks/task_e_689fd57b3c18832e92419b6b9fc8c46c