### PR TITLE
feat: warn before revoking dependent privileges

### DIFF
--- a/gerenciador_postgres/executor.py
+++ b/gerenciador_postgres/executor.py
@@ -30,8 +30,18 @@ class Executor:
         self.retry_interval = retry_interval
 
     # ------------------------------------------------------------------
-    def apply(self, operations: Iterable[Mapping[str, object]]):
+    def apply(self, operations: Iterable[Mapping[str, object]], *, check_warnings: bool = True):
         ops = list(operations)
+        if check_warnings:
+            for op in ops:
+                badge = op.get("badge")
+                if badge:
+                    schema = op.get("schema", "")
+                    obj = op.get("object", "")
+                    deps = op.get("dependencies")
+                    raise RuntimeError(
+                        f"[{badge}] {schema}.{obj} possui dependências: {deps}"
+                    )
         attempt = 0
         while True:
             attempt += 1

--- a/gerenciador_postgres/reconciler.py
+++ b/gerenciador_postgres/reconciler.py
@@ -162,16 +162,19 @@ class Reconciler:
                     to_grant = desired_set - current_set
                     to_revoke = current_set - desired_set
                     if to_revoke:
-                        ops.append(
-                            {
-                                "action": "revoke",
-                                "target": keyword,
-                                "schema": schema,
-                                "object": obj,
-                                "grantee": role,
-                                "privileges": sorted(to_revoke),
-                            }
-                        )
+                        op = {
+                            "action": "revoke",
+                            "target": keyword,
+                            "schema": schema,
+                            "object": obj,
+                            "grantee": role,
+                            "privileges": sorted(to_revoke),
+                        }
+                        deps = state_reader.get_dependencies(self.conn, schema, obj)
+                        if deps:
+                            op["badge"] = "WARN-DEPEND"
+                            op["dependencies"] = deps
+                        ops.append(op)
                     if to_grant:
                         ops.append(
                             {

--- a/tests/integration/test_dependency_warning.py
+++ b/tests/integration/test_dependency_warning.py
@@ -1,68 +1,67 @@
 import os
-import sys
 import pathlib
+import sys
 
-import pytest
 import psycopg2
+import pytest
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
-from gerenciador_postgres.db_manager import DBManager
+from gerenciador_postgres import executor, reconciler
 
 pytestmark = pytest.mark.integration
 
 
 @pytest.fixture(scope="module")
 def conn():
-    conn = psycopg2.connect(
-        host=os.getenv("PGHOST", "localhost"),
-        port=os.getenv("PGPORT", "5432"),
-        dbname=os.getenv("PGDATABASE", "postgres"),
-        user=os.getenv("PGUSER", "postgres"),
-        password=os.getenv("PGPASSWORD", "postgres"),
-    )
+    try:
+        conn = psycopg2.connect(
+            host=os.getenv("PGHOST", "localhost"),
+            port=os.getenv("PGPORT", "5432"),
+            dbname=os.getenv("PGDATABASE", "postgres"),
+            user=os.getenv("PGUSER", "postgres"),
+            password=os.getenv("PGPASSWORD", "postgres"),
+        )
+    except psycopg2.OperationalError as e:  # pragma: no cover - depends on env
+        pytest.skip(f"PostgreSQL not available: {e}")
     yield conn
     conn.close()
 
 
-def test_revoke_warns_on_dependencies(conn):
-    db = DBManager(conn)
-    cur = conn.cursor()
+def _cleanup(cur):
     cur.execute("DROP VIEW IF EXISTS public.dep_view")
     cur.execute("DROP TABLE IF EXISTS public.dep_base CASCADE")
     cur.execute("DROP ROLE IF EXISTS dep_role")
+
+
+def test_dependency_warning_flow(conn):
+    cur = conn.cursor()
+    _cleanup(cur)
     cur.execute("CREATE ROLE dep_role NOLOGIN")
     cur.execute("CREATE TABLE public.dep_base(id int)")
     cur.execute("CREATE VIEW public.dep_view AS SELECT * FROM public.dep_base")
     cur.execute("GRANT SELECT ON public.dep_base TO dep_role")
     conn.commit()
     try:
-        with pytest.raises(RuntimeError) as excinfo:
-            with db.transaction():
-                db.apply_group_privileges(
-                    "dep_role",
-                    {"public": {"dep_base": set()}},
-                    check_dependencies=True,
-                )
-        assert "[WARN-DEPEND]" in str(excinfo.value)
-        conn.rollback()
+        contract = {"object_privileges": {"dep_role": {"public": {"dep_base": []}}}}
+        rec = reconciler.Reconciler(conn)
+        ops = rec.diff(contract)
+        assert ops and ops[0].get("badge") == "WARN-DEPEND"
 
-        with db.transaction():
-            db.apply_group_privileges(
-                "dep_role",
-                {"public": {"dep_base": set()}},
-                check_dependencies=False,
-            )
+        execu = executor.Executor(conn)
+        with pytest.raises(RuntimeError) as excinfo:
+            execu.apply(ops)
+        assert "[WARN-DEPEND]" in str(excinfo.value)
+
+        execu.apply(ops, check_warnings=False)
         cur.execute(
             """
-            SELECT privilege_type
-            FROM information_schema.role_table_grants
+            SELECT privilege_type FROM information_schema.role_table_grants
             WHERE grantee='dep_role' AND table_name='dep_base'
             """
         )
         assert cur.fetchone() is None
     finally:
-        cur.execute("DROP VIEW IF EXISTS public.dep_view")
-        cur.execute("DROP TABLE IF EXISTS public.dep_base")
-        cur.execute("DROP ROLE IF EXISTS dep_role")
+        _cleanup(cur)
         conn.commit()
+


### PR DESCRIPTION
## Summary
- warn when revoking privileges on objects with dependencies
- halt executor unless dependency warnings are confirmed
- test dependency warning flow for reconciler and executor

## Testing
- `pytest` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689fe28d66d8832e8db8d3558a561984