### PR TITLE
Use pg_catalog ACL queries with grant option preservation

### DIFF
--- a/tests/test_apply_group_privileges_diff.py
+++ b/tests/test_apply_group_privileges_diff.py
@@ -17,15 +17,17 @@ class DummyCursor:
 
     def execute(self, sql_query, params=None):
         query = str(sql_query)
-        if "information_schema.role_table_grants" in query:
+        if "FROM pg_class" in query and "aclexplode" in query:
             self.result = [
-                (schema, table, priv)
+                (schema, table, priv.rstrip("*"), priv.endswith("*"))
                 for schema, objs in self.current_privs.items()
                 for table, privs in objs.items()
                 for priv in privs
             ]
         elif self.record and ("GRANT" in query or "REVOKE" in query):
             self.executed.append(query)
+        else:
+            self.result = []
 
     def fetchall(self):
         return self.result

--- a/tests/test_db_manager_tables.py
+++ b/tests/test_db_manager_tables.py
@@ -22,7 +22,7 @@ class DummyCursor:
         pass
 
     def execute(self, sql, params=None):
-        if "information_schema.schemata" in sql:
+        if "FROM pg_namespace" in sql:
             self.result = [(s,) for s in self.data["schemas"]]
         elif "FROM pg_catalog.pg_class" in sql:
             self.result = self.data["tables"]

--- a/tests/test_default_privileges.py
+++ b/tests/test_default_privileges.py
@@ -43,9 +43,14 @@ class DummyConn:
 
 def test_get_default_privileges_parsing():
     rows = [
-        ("postgres", "geo2", ['"grp_Geo2_2025-2"=arwd/postgres']),
-        ("postgres", "public", ['"grp_Geo2_2025-2"=r/postgres']),
-        ("postgres", "Teste_001_Esquema", ['"grp_Geo2_2025-2"=arw/postgres']),
+        ("postgres", "geo2", "grp_Geo2_2025-2", "DELETE", False),
+        ("postgres", "geo2", "grp_Geo2_2025-2", "INSERT", False),
+        ("postgres", "geo2", "grp_Geo2_2025-2", "SELECT", False),
+        ("postgres", "geo2", "grp_Geo2_2025-2", "UPDATE", False),
+        ("postgres", "public", "grp_Geo2_2025-2", "SELECT", False),
+        ("postgres", "Teste_001_Esquema", "grp_Geo2_2025-2", "INSERT", False),
+        ("postgres", "Teste_001_Esquema", "grp_Geo2_2025-2", "SELECT", False),
+        ("postgres", "Teste_001_Esquema", "grp_Geo2_2025-2", "UPDATE", False),
     ]
     conn = DummyConn(rows)
     db = DBManager(conn)

--- a/tests/test_grant_schema_privileges_diff.py
+++ b/tests/test_grant_schema_privileges_diff.py
@@ -33,10 +33,10 @@ class DummyCursor:
 
         query = _to_str(sql_query)
         self.commands.append(query)
-        if "information_schema.schema_privileges" in query:
+        if "FROM pg_namespace" in query:
             role, schema = params
             privs = self.conn.grants.get((role, schema), set())
-            self.result = [(p,) for p in sorted(privs)]
+            self.result = [(p.rstrip("*"), p.endswith("*")) for p in sorted(privs)]
         elif query.strip().upper().startswith("GRANT"):
             import re
 

--- a/tests/test_schema_privileges_group.py
+++ b/tests/test_schema_privileges_group.py
@@ -36,12 +36,10 @@ class DummyCursor:
     def execute(self, sql, params=None):
         self.commands.append(sql)
         sql_str = str(sql)
-        if "information_schema.schema_privileges" in sql_str:
-            self.result = [
-                (schema, priv)
-                for schema, privs in self.conn.grants.items()
-                for priv in sorted(privs)
-            ]
+        if "FROM pg_namespace" in sql_str:
+            role, schema = params
+            privs = self.conn.grants.get(schema, set())
+            self.result = [(priv.rstrip("*"), priv.endswith("*")) for priv in sorted(privs)]
         else:
             self.result = []
 

--- a/tests/test_state_reader.py
+++ b/tests/test_state_reader.py
@@ -109,9 +109,14 @@ class DummyConnDefaults:
 
 def test_get_default_privileges_parsing():
     rows = [
-        ("postgres", "geo2", ['"grp_Geo2_2025-2"=arwd/postgres']),
-        ("postgres", "public", ['"grp_Geo2_2025-2"=r/postgres']),
-        ("postgres", "Teste_001_Esquema", ['"grp_Geo2_2025-2"=arw/postgres']),
+        ("postgres", "geo2", "grp_Geo2_2025-2", "DELETE", False),
+        ("postgres", "geo2", "grp_Geo2_2025-2", "INSERT", False),
+        ("postgres", "geo2", "grp_Geo2_2025-2", "SELECT", False),
+        ("postgres", "geo2", "grp_Geo2_2025-2", "UPDATE", False),
+        ("postgres", "public", "grp_Geo2_2025-2", "SELECT", False),
+        ("postgres", "Teste_001_Esquema", "grp_Geo2_2025-2", "INSERT", False),
+        ("postgres", "Teste_001_Esquema", "grp_Geo2_2025-2", "SELECT", False),
+        ("postgres", "Teste_001_Esquema", "grp_Geo2_2025-2", "UPDATE", False),
     ]
     conn = DummyConnDefaults(rows)
     res = state_reader.get_default_privileges(conn, owner="postgres")


### PR DESCRIPTION
## Summary
- Read object ACLs from `pg_catalog` using `aclexplode` and retain grant options
- Migrate schema, table, and default privilege lookups to `pg_catalog`
- Update tests for new ACL queries and grant option handling

## Testing
- `PYTHONPATH=. pytest tests/test_apply_group_privileges_diff.py tests/test_default_privileges.py tests/test_db_manager_tables.py tests/test_state_reader.py tests/test_grant_schema_privileges_diff.py tests/test_schema_privileges_group.py -q`
- `PYTHONPATH=. pytest -q` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689fe81dee94832e81cf56567401c828