### PR TITLE
Adjust role prefix patterns and filtering

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ databases:
   port: 5432
   user: Bettina
 group_prefix: turma_
-user_prefix: monitores_
+user_prefix: "monitores_*"
 log_level: DEBUG
 log_path: D:\GitHub\IFSC_SGBD\logs\app.log
 schema_creation_group: Professores

--- a/contracts/example_contract_basic.json
+++ b/contracts/example_contract_basic.json
@@ -3,5 +3,5 @@
   "scope": {"database": "example", "schema": "public"},
   "managed_principals_mode": "regex",
   "auto_onboard_creators": false,
-  "managed_principals": ["^turma_[A-Za-z0-9_]+$", "^monitores_[A-Za-z0-9_]+$"]
+  "managed_principals": ["^turma_.*$", "^monitores_.*$"]
 }

--- a/contracts/permission_contract.py
+++ b/contracts/permission_contract.py
@@ -148,7 +148,7 @@ DEFAULT_CONTRACT = validate_contract(
         "managed_principals_mode": "regex",
         "auto_onboard_creators": False,
         # Application-managed role name patterns
-        "managed_principals": [r"^turma_[A-Za-z0-9_]+$", r"^monitores_[A-Za-z0-9_]+$"],
+        "managed_principals": [r"^turma_.*$", r"^monitores_.*$"],
     }
 )
 

--- a/gerenciador_postgres/config_manager.py
+++ b/gerenciador_postgres/config_manager.py
@@ -18,7 +18,7 @@ DEFAULT_CONFIG = {
     "log_path": str(BASE_DIR / "logs" / "app.log"),
     "log_level": "INFO",
     "group_prefix": "turma_",
-    "user_prefix": "monitores_",
+    "user_prefix": "monitores_*",
     "schema_creation_group": "Professores",
     "connect_timeout": 5,
 }

--- a/gerenciador_postgres/state_reader.py
+++ b/gerenciador_postgres/state_reader.py
@@ -18,6 +18,8 @@ from typing import Dict, Iterable, List, Set, Tuple
 from psycopg2.extensions import connection
 from psycopg2 import sql
 
+from contracts.permission_contract import filter_managed
+
 from .db_manager import DBManager
 
 # ---------------------------------------------------------------------------
@@ -33,7 +35,7 @@ def list_roles(conn: connection) -> List[str]:
     )
     with conn.cursor() as cur:
         cur.execute(query)
-        return [row[0] for row in cur.fetchall()]
+        return filter_managed([row[0] for row in cur.fetchall()])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -23,7 +23,7 @@ def test_load_config_creates_file(tmp_path, monkeypatch):
     assert data["log_level"] == "INFO"
     assert "log_path" in data
     assert data["group_prefix"] == "turma_"
-    assert data["user_prefix"] == "monitores_"
+    assert data["user_prefix"] == "monitores_*"
     assert data["schema_creation_group"] == "Professores"
     assert data["connect_timeout"] == 5
 

--- a/tests/test_state_reader.py
+++ b/tests/test_state_reader.py
@@ -133,3 +133,28 @@ def test_get_default_privileges_parsing():
         "UPDATE",
     }
     assert res["_meta"]["owner_roles"]["geo2"] == "postgres"
+
+
+class DummyCursorRoles:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def execute(self, sql, params=None):
+        pass
+
+    def fetchall(self):
+        return [("turma_teste",), ("monitores_abc",), ("outro",)]
+
+
+class DummyConnRoles:
+    def cursor(self):
+        return DummyCursorRoles()
+
+
+def test_list_roles_filters_managed():
+    conn = DummyConnRoles()
+    roles = state_reader.list_roles(conn)
+    assert roles == ["turma_teste", "monitores_abc"]


### PR DESCRIPTION
## Summary
- use `turma_` and `monitores_*` prefixes in default config and permission contract
- filter roles with managed prefixes in state_reader
- add tests for updated prefixes and role filtering

## Testing
- `pytest -m "not integration"`
- `pytest` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689feca45748832e90178eebc44a3b66