### PR TITLE
Handle missing PostgreSQL in integration tests

### DIFF
--- a/tests/integration/test_postgres_integration.py
+++ b/tests/integration/test_postgres_integration.py
@@ -13,13 +13,16 @@ pytestmark = pytest.mark.integration
 
 @pytest.fixture(scope="module")
 def conn():
-    conn = psycopg2.connect(
-        host=os.getenv("PGHOST", "localhost"),
-        port=os.getenv("PGPORT", "5432"),
-        dbname=os.getenv("PGDATABASE", "postgres"),
-        user=os.getenv("PGUSER", "postgres"),
-        password=os.getenv("PGPASSWORD", "postgres"),
-    )
+    try:
+        conn = psycopg2.connect(
+            host=os.getenv("PGHOST", "localhost"),
+            port=os.getenv("PGPORT", "5432"),
+            dbname=os.getenv("PGDATABASE", "postgres"),
+            user=os.getenv("PGUSER", "postgres"),
+            password=os.getenv("PGPASSWORD", "postgres"),
+        )
+    except psycopg2.OperationalError as e:
+        pytest.skip(f"PostgreSQL not available: {e}")
     yield conn
     conn.close()
 


### PR DESCRIPTION
## Summary
- Skip integration tests when PostgreSQL server isn't available by catching OperationalError during fixture setup.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689feccb1be8832e8cb24edbfd7bedfa