### PR TITLE
Allow group creation in users view

### DIFF
--- a/gerenciador_postgres/controllers/users_controller.py
+++ b/gerenciador_postgres/controllers/users_controller.py
@@ -75,6 +75,26 @@ class UsersController(QObject):
     def list_groups(self):
         return self.role_manager.list_groups()
 
+    def create_group(self, group_name: str):
+        result = self.role_manager.create_group(group_name)
+        self.data_changed.emit()
+        return result
+
+    def delete_group(self, group_name: str) -> bool:
+        success = self.role_manager.delete_group(group_name)
+        if success:
+            self.data_changed.emit()
+        return success
+
+    def delete_group_and_members(self, group_name: str) -> bool:
+        success = self.role_manager.delete_group_and_members(group_name)
+        if success:
+            self.data_changed.emit()
+        return success
+
+    def list_group_members(self, group_name: str):
+        return self.role_manager.list_group_members(group_name)
+
     def list_user_groups(self, username: str):
         return self.role_manager.list_user_groups(username)
 


### PR DESCRIPTION
## Summary
- Add controller methods to create and delete groups
- Move group creation and removal to users view
- Remove group management actions from groups view

## Testing
- `pytest` *(fails: AttributeError: 'ConnectionManager' object has no attribute '_thread_local')*

------
https://chatgpt.com/codex/tasks/task_e_68a5c66a6458832eaa83bc580c998011