### PR TITLE
Move group management buttons to sidebar

### DIFF
--- a/gerenciador_postgres/gui/users_view.py
+++ b/gerenciador_postgres/gui/users_view.py
@@ -23,7 +23,6 @@ from PyQt6.QtWidgets import (
     QListWidget,
     QInputDialog,
     QProgressDialog,
-    QToolBar,
     QApplication,
 )
 from PyQt6.QtCore import Qt, QDate
@@ -352,6 +351,8 @@ class UsersView(QWidget):
         self.btnInserirLote = QPushButton("Inserir Usuários em Lote")
         self.btnExcluirLote = QPushButton("Deletar Usuários em Lote")
         self.btnEditarExpLote = QPushButton("Editar Expiração em Lote")
+        self.btnNewGroup = QPushButton("Criar Grupo")
+        self.btnDeleteGroup = QPushButton("Excluir Grupo")
         self.btnRefreshGrupos = QPushButton("Recarregar Grupos")
         for b in (
             self.btnNovo,
@@ -360,9 +361,23 @@ class UsersView(QWidget):
             self.btnInserirLote,
             self.btnExcluirLote,
             self.btnEditarExpLote,
-            self.btnRefreshGrupos,
         ):
             left.addWidget(b)
+
+        group_actions = QWidget()
+        group_actions.setObjectName("group-actions-group")
+        group_actions.setStyleSheet(
+            "#group-actions-group {background-color: #E8F6E8; border: 1px solid #C4D7C4;}"
+        )
+        ga_layout = QVBoxLayout(group_actions)
+        for b in (
+            self.btnNewGroup,
+            self.btnDeleteGroup,
+            self.btnRefreshGrupos,
+        ):
+            ga_layout.addWidget(b)
+        left.addWidget(group_actions)
+
         left.addStretch()
         root.addLayout(left, 0)
 
@@ -392,12 +407,6 @@ class UsersView(QWidget):
         # Painel de grupos
         self.groupPanel = QWidget()
         gp_layout = QVBoxLayout(self.groupPanel)
-        toolbar = QToolBar()
-        self.btnNewGroup = QPushButton("Criar Grupo")
-        self.btnDeleteGroup = QPushButton("Excluir Grupo")
-        toolbar.addWidget(self.btnNewGroup)
-        toolbar.addWidget(self.btnDeleteGroup)
-        gp_layout.addWidget(toolbar)
         gp_layout.addWidget(QLabel("Gerenciamento de Grupos do Usuário Selecionado"))
         lists_layout = QHBoxLayout()
         # Grupos do usuário


### PR DESCRIPTION
## Summary
- Move "Criar Grupo", "Excluir Grupo" and "Recarregar Grupos" buttons into the left sidebar
- Style new `group-actions-group` container with soft background and border for visual separation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5cb17655c832e96702f48aa920946