### PR TITLE
Enable selecting multiple groups for deletion with confirmation

### DIFF
--- a/gerenciador_postgres/gui/users_view.py
+++ b/gerenciador_postgres/gui/users_view.py
@@ -592,45 +592,77 @@ class UsersView(QWidget):
             self._refresh_group_lists()
         except Exception as e:
             QMessageBox.critical(self, "Erro", f"Não foi possível criar o grupo.\nMotivo: {e}")
+        
+    def _select_groups_for_deletion(self) -> list[str]:
+        if not self.controller:
+            return []
+        try:
+            groups = sorted(self.controller.list_groups())
+        except Exception as e:
+            QMessageBox.critical(self, "Erro", f"Falha ao listar grupos: {e}")
+            return []
+        if not groups:
+            QMessageBox.information(self, "Atenção", "Não há grupos disponíveis.")
+            return []
+        dlg = QDialog(self)
+        dlg.setWindowTitle("Selecionar Grupos")
+        layout = QVBoxLayout(dlg)
+        lst = QListWidget()
+        lst.addItems(groups)
+        lst.setSelectionMode(QAbstractItemView.SelectionMode.MultiSelection)
+        layout.addWidget(lst)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(dlg.accept)
+        buttons.rejected.connect(dlg.reject)
+        layout.addWidget(buttons)
+        if dlg.exec() != QDialog.DialogCode.Accepted:
+            return []
+        return [item.text() for item in lst.selectedItems()]
 
     def _on_delete_group(self):
-        item = self.lstAllGroups.currentItem() or self.lstUserGroups.currentItem()
-        if not item:
+        groups = self._select_groups_for_deletion()
+        if not groups:
             return
-        group = item.text()
-        members = self.controller.list_group_members(group)
-        if members:
-            msg = (
-                f"O grupo '{group}' possui {len(members)} membro(s).\n"
-                "Deseja removê-los junto com o grupo?"
-            )
-            reply = QMessageBox.question(
-                self,
-                "Grupo com membros",
-                msg,
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                QMessageBox.StandardButton.No,
-            )
-            if reply == QMessageBox.StandardButton.Yes:
-                success = self.controller.delete_group_and_members(group)
+        for group in groups:
+            members = self.controller.list_group_members(group)
+            if members:
+                msg = (
+                    f"O grupo '{group}' possui {len(members)} membro(s).\n"
+                    "Deseja removê-los junto com o grupo?"
+                )
+                reply = QMessageBox.question(
+                    self,
+                    "Grupo com membros",
+                    msg,
+                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                    QMessageBox.StandardButton.No,
+                )
+                if reply == QMessageBox.StandardButton.Yes:
+                    success = self.controller.delete_group_and_members(group)
+                else:
+                    success = self.controller.delete_group(group)
             else:
+                reply = QMessageBox.question(
+                    self,
+                    "Confirmar Deleção",
+                    f"Tem certeza que deseja excluir o grupo '{group}'?",
+                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                    QMessageBox.StandardButton.No,
+                )
+                if reply != QMessageBox.StandardButton.Yes:
+                    continue
                 success = self.controller.delete_group(group)
-        else:
-            reply = QMessageBox.question(
-                self,
-                "Confirmar Deleção",
-                f"Tem certeza que deseja excluir o grupo '{group}'?",
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                QMessageBox.StandardButton.No,
-            )
-            if reply != QMessageBox.StandardButton.Yes:
-                return
-            success = self.controller.delete_group(group)
-        if success:
-            QMessageBox.information(
-                self, "Sucesso", f"Grupo '{group}' excluído com sucesso."
-            )
-            self._refresh_group_lists()
+            if success:
+                QMessageBox.information(
+                    self, "Sucesso", f"Grupo '{group}' excluído com sucesso."
+                )
+            else:
+                QMessageBox.critical(
+                    self, "Erro", f"Falha ao excluir o grupo '{group}'."
+                )
+        self._refresh_group_lists()
 
     # ------------------------------------------------------------------
     # Operações

--- a/tests/test_groups_view.py
+++ b/tests/test_groups_view.py
@@ -1,10 +1,8 @@
-import types
-from types import SimpleNamespace
 import pytest
 pytest.importorskip("PyQt6.QtWidgets")
 from PyQt6.QtWidgets import QMessageBox
 
-from gerenciador_postgres.gui.groups_view import PrivilegesView
+from gerenciador_postgres.gui.users_view import UsersView
 
 
 class DummyController:
@@ -23,13 +21,14 @@ class DummyController:
         self.deleted_with_members = group
         return True
 
+    def list_groups(self):
+        return ["grp_test"]
+
 
 def _make_view(controller):
-    view = PrivilegesView.__new__(PrivilegesView)
+    view = UsersView.__new__(UsersView)
     view.controller = controller
-    view.lstGroups = SimpleNamespace(
-        currentItem=lambda: SimpleNamespace(text=lambda: "grp_test")
-    )
+    view._refresh_group_lists = lambda: None
     return view
 
 
@@ -37,15 +36,18 @@ def test_delete_group_without_removing_members(monkeypatch):
     controller = DummyController()
     view = _make_view(controller)
     monkeypatch.setattr(
-        "gerenciador_postgres.gui.groups_view.QMessageBox.question",
+        UsersView, "_select_groups_for_deletion", lambda self: ["grp_test"]
+    )
+    monkeypatch.setattr(
+        "gerenciador_postgres.gui.users_view.QMessageBox.question",
         lambda *a, **k: QMessageBox.StandardButton.No,
     )
     monkeypatch.setattr(
-        "gerenciador_postgres.gui.groups_view.QMessageBox.information",
+        "gerenciador_postgres.gui.users_view.QMessageBox.information",
         lambda *a, **k: None,
     )
     monkeypatch.setattr(
-        "gerenciador_postgres.gui.groups_view.QMessageBox.critical",
+        "gerenciador_postgres.gui.users_view.QMessageBox.critical",
         lambda *a, **k: None,
     )
 


### PR DESCRIPTION
## Summary
- allow choosing multiple groups at once for deletion
- confirm each group's removal and handle groups with members
- adjust tests for new deletion workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7a9a01d6c832e9721c0bd7115aa52