### PR TITLE
Ensure acldefault receives char argument

### DIFF
--- a/gerenciador_postgres/state_reader.py
+++ b/gerenciador_postgres/state_reader.py
@@ -102,11 +102,16 @@ def get_object_acls(
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
         CROSS JOIN LATERAL aclexplode(
-            COALESCE(c.relacl,
-                     acldefault(
-                         CASE WHEN c.relkind = 'S' THEN 'S' ELSE 'r' END,
-                         c.relowner
-                     ))
+            COALESCE(
+                c.relacl,
+                acldefault(
+                    CASE
+                        WHEN c.relkind = 'S'::"char" THEN c.relkind
+                        ELSE 'r'::"char"
+                    END,
+                    c.relowner
+                )
+            )
         ) AS a
         LEFT JOIN pg_roles gr ON gr.oid = a.grantee
         WHERE n.nspname = %s AND c.relname = %s


### PR DESCRIPTION
## Summary
- cast relkind literals to type char when defaulting ACLs

## Testing
- `pytest tests/integration/test_dependency_warning.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7acaf83a4832eb70d47e0cc735e4d