### PR TITLE
Make logger optional in RoleManager

### DIFF
--- a/gerenciador_postgres/role_manager.py
+++ b/gerenciador_postgres/role_manager.py
@@ -10,9 +10,15 @@ from config.permission_templates import DEFAULT_TEMPLATE
 
 class RoleManager:
     """Camada de serviço: orquestra operações, valida regras e controla transações."""
-    def __init__(self, dao: DBManager, logger: logging.Logger, operador: str = 'sistema', audit_manager=None):
+    def __init__(
+        self,
+        dao: DBManager,
+        logger: logging.Logger | None = None,
+        operador: str = 'sistema',
+        audit_manager=None,
+    ):
         self.dao = dao
-        self.logger = logger
+        self.logger = logger or logging.getLogger(__name__)
         self.operador = operador
         self.audit_manager = audit_manager
 


### PR DESCRIPTION
## Summary
- Allow RoleManager to be instantiated without an explicit logger and fallback to module logger

## Testing
- `pytest tests/integration/test_revoke_confirmation.py -q` *(skipped: missing PyQt6 libGL)*

------
https://chatgpt.com/codex/tasks/task_e_68a7acb72238832eb3afe63f1ef8f0dc