### PR TITLE
Ensure dependency warning check iterates over all operations

### DIFF
--- a/tests/integration/test_dependency_warning.py
+++ b/tests/integration/test_dependency_warning.py
@@ -46,7 +46,7 @@ def test_dependency_warning_flow(conn):
         contract = {"object_privileges": {"dep_role": {"public": {"dep_base": []}}}}
         rec = reconciler.Reconciler(conn)
         ops = rec.diff(contract)
-        assert ops and ops[0].get("badge") == "WARN-DEPEND"
+        assert any(op.get("badge") == "WARN-DEPEND" for op in ops)
 
         execu = executor.Executor(conn)
         with pytest.raises(RuntimeError) as excinfo:


### PR DESCRIPTION
## Summary
- relax dependency warning assertion by checking all ops for WARN-DEPEND badge

## Testing
- `pytest tests/integration/test_dependency_warning.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7ae758cd0832ebda55bff9638ce1a