### PR TITLE
Add rollback before test cleanup for clean transactions

### DIFF
--- a/tests/integration/test_dependency_warning.py
+++ b/tests/integration/test_dependency_warning.py
@@ -62,6 +62,7 @@ def test_dependency_warning_flow(conn):
         )
         assert cur.fetchone() is None
     finally:
+        conn.rollback()
         _cleanup(cur)
         conn.commit()
 

--- a/tests/integration/test_reconciler_executor.py
+++ b/tests/integration/test_reconciler_executor.py
@@ -97,6 +97,7 @@ def test_reconcile_apply_roundtrip(conn):
         )
         assert cur.fetchone() is None
     finally:
+        conn.rollback()
         _cleanup(cur)
         conn.commit()
 
@@ -157,5 +158,6 @@ def test_default_privileges_roundtrip(conn):
         )
         assert cur.fetchone() is None
     finally:
+        conn.rollback()
         _cleanup_defaults(cur)
         conn.commit()


### PR DESCRIPTION
## Summary
- Ensure integration tests rollback transactions before cleanup to avoid residual state

## Testing
- `pytest tests/integration -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7ae8a020c832e9cc152a4cda902e6