### PR TITLE
Use has_schema_privilege for schema privilege checks

### DIFF
--- a/tests/integration/test_reconciler_executor.py
+++ b/tests/integration/test_reconciler_executor.py
@@ -59,12 +59,9 @@ def test_reconcile_apply_roundtrip(conn):
         execu.apply(ops)
 
         cur.execute(
-            """
-            SELECT privilege_type FROM information_schema.schema_privileges
-            WHERE grantee='recon_role' AND schema_name='public'
-            """
+            "SELECT pg_catalog.has_schema_privilege('recon_role', 'public', 'USAGE')"
         )
-        assert {row[0] for row in cur.fetchall()} == {"USAGE"}
+        assert cur.fetchone()[0]
         cur.execute(
             """
             SELECT privilege_type FROM information_schema.role_table_grants
@@ -83,12 +80,9 @@ def test_reconcile_apply_roundtrip(conn):
         ops2 = rec.diff(contract2)
         execu.apply(ops2)
         cur.execute(
-            """
-            SELECT privilege_type FROM information_schema.schema_privileges
-            WHERE grantee='recon_role' AND schema_name='public'
-            """
+            "SELECT pg_catalog.has_schema_privilege('recon_role', 'public', 'USAGE')"
         )
-        assert cur.fetchone() is None
+        assert not cur.fetchone()[0]
         cur.execute(
             """
             SELECT privilege_type FROM information_schema.role_table_grants


### PR DESCRIPTION
## Summary
- Replace information_schema schema_privileges queries with pg_catalog.has_schema_privilege in integration tests

## Testing
- `pytest tests/integration/test_reconciler_executor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7ae842e54832ea63b9a3a430fc853