### PR TITLE
Remove sweep privilege synchronization feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,6 @@ python Rodar.py
 
 Senhas nunca são salvas; use variável de ambiente `<PERFIL>_PASSWORD` ou o keyring (`IFSC_SGBD`, conta = usuário).
 
-## Sincronização de privilégios
-
-Após salvar permissões de schemas, tabelas ou padrões futuros, o sistema **não executa mais** a sincronização automática de privilégios. Caso seja necessário alinhar privilégios antigos com o estado atual do banco:
-
-- Na interface gráfica, utilize o botão **"Sincronizar (Full Sweep)"** disponível nas telas de grupos e de privilégios.
-- Pela linha de comando, execute `scripts/sweep_privileges.py --profile <perfil> [--group <grupo>]` para sincronizar todos os grupos ou apenas o grupo informado.
-
 ## Contrato de Permissões
 
 A aplicação suporta definição de contratos de permissões no formato JSON para gerenciar papéis e privilégios no banco de dados.

--- a/gerenciador_postgres/controllers/groups_controller.py
+++ b/gerenciador_postgres/controllers/groups_controller.py
@@ -246,18 +246,3 @@ class GroupsController(QObject):
 
     def get_current_database(self):
         return self.role_manager.dao.conn.get_dsn_parameters().get("dbname")
-
-    # ---------------------------------------------------------------
-    # Sincronização (sweep) de privilégios
-    # ---------------------------------------------------------------
-    def sweep_group_privileges(self, group_name: str) -> bool:
-        """Reaplica GRANTs e ajusta default privileges para o grupo informado."""
-        try:
-            success = self.role_manager.sweep_privileges(target_group=group_name)
-        except Exception as e:
-            if "[WARN-DEPEND]" in str(e):
-                raise DependencyWarning(str(e))
-            raise
-        if success:
-            self.data_changed.emit()
-        return success

--- a/gerenciador_postgres/controllers/users_controller.py
+++ b/gerenciador_postgres/controllers/users_controller.py
@@ -5,8 +5,7 @@ class UsersController(QObject):
     """Controller responsável pelas operações de usuário.
 
     Este controller orquestra chamadas de criação/atualização/exclusão de
-    usuários e gerencia ações correlatas, como sincronização de privilégios
-    após operações em lote.
+    usuários e gerencia ações correlatas após operações em lote.
     """
 
     data_changed = pyqtSignal()

--- a/tests/test_schema_privileges_group.py
+++ b/tests/test_schema_privileges_group.py
@@ -90,7 +90,6 @@ def test_grant_and_display_schema_privileges():
     view.treePrivileges = QTreeWidget()
     view.btnApplyTemplate = QPushButton()
     view.btnSave = QPushButton()
-    view.btnSweep = QPushButton()
     view.lstMembers = QListWidget()
 
     view._populate_privileges()


### PR DESCRIPTION
## Summary
- drop Full Sweep button and wiring from privileges view
- remove deprecated sweep_privileges handlers and controller method
- clean documentation and tests of synchronization references

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7b2f112b0832e827d4c4bd4e865d6