### PR TITLE
Apply default privileges for multiple owners

### DIFF
--- a/gerenciador_postgres/gui/privileges_view.py
+++ b/gerenciador_postgres/gui/privileges_view.py
@@ -17,6 +17,8 @@ from PyQt6.QtWidgets import (
     QCheckBox,
     QToolBar,
     QInputDialog,
+    QDialog,
+    QDialogButtonBox,
 )
 from PyQt6.QtCore import Qt, QThread, pyqtSignal
 from PyQt6.QtGui import QIcon
@@ -171,8 +173,10 @@ class PrivilegesView(QWidget):
         schema_btns = QHBoxLayout()
         self.btnSaveSchema = QPushButton("Salvar Schema")
         self.btnSaveDefaults = QPushButton("Salvar Defaults")
+        self.btnApplyDefaults = QPushButton("Aplicar para...")
         schema_btns.addWidget(self.btnSaveSchema)
         schema_btns.addWidget(self.btnSaveDefaults)
+        schema_btns.addWidget(self.btnApplyDefaults)
         schema_btns.addStretch(1)
         schema_tab_layout.addLayout(schema_btns)
         self.tabs.addTab(schema_tab, "Schemas")
@@ -216,6 +220,7 @@ class PrivilegesView(QWidget):
             self.btnSaveDb,
             self.btnSaveSchema,
             self.btnSaveDefaults,
+            self.btnApplyDefaults,
             self.btnSaveTables,
             self.btnSaveAll,
             self.btnReloadTables,
@@ -233,6 +238,7 @@ class PrivilegesView(QWidget):
         self.btnSaveDb.clicked.connect(self._save_db_privileges)
         self.btnSaveSchema.clicked.connect(self._save_schema_privileges)
         self.btnSaveDefaults.clicked.connect(self._save_default_privileges)
+        self.btnApplyDefaults.clicked.connect(self._apply_defaults_for)
         self.btnSaveTables.clicked.connect(self._save_table_privileges)
         self.btnSaveAll.clicked.connect(self._save_all_privileges)
         self.btnReloadTables.clicked.connect(self._reload_tables)
@@ -1157,7 +1163,42 @@ class PrivilegesView(QWidget):
             QMessageBox.critical(self, "Erro", f"Falha ao recarregar tabelas: {e}")
         self._execute_async(task, on_success, on_error, "Recarregando tabelas...")
 
-    def _save_default_privileges(self):
+    def _apply_defaults_for(self):
+        if not self.current_group or not self.controller:
+            return
+        members = self.controller.list_group_members(self.current_group)
+        dlg = QDialog(self)
+        dlg.setWindowTitle("Aplicar defaults para")
+        layout = QVBoxLayout(dlg)
+        lst = QListWidget()
+        lst.setSelectionMode(QListWidget.SelectionMode.MultiSelection)
+        lst.addItem("Todos os membros")
+        for m in members:
+            lst.addItem(m)
+
+        def select_all():
+            first = lst.item(0)
+            if first.isSelected():
+                lst.selectAll()
+
+        lst.itemSelectionChanged.connect(select_all)
+        layout.addWidget(lst)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(dlg.accept)
+        buttons.rejected.connect(dlg.reject)
+        layout.addWidget(buttons)
+        if dlg.exec():
+            owners = [
+                lst.item(i).text()
+                for i in range(1, lst.count())
+                if lst.item(i).isSelected()
+            ]
+            if owners:
+                self._save_default_privileges(owners)
+
+    def _save_default_privileges(self, owners=None):
         role, schema = self._current_schema_checked()
         if not role:
             return
@@ -1165,10 +1206,14 @@ class PrivilegesView(QWidget):
         default_perms = set(state.default_privs) if state else set()
 
         def task():
-            owner = state.owner_role if state else None
-            return self.controller.alter_default_privileges(
-                role, schema, "tables", default_perms, owner=owner, emit_signal=False
-            )
+            owners_list = owners if owners is not None else [state.owner_role if state else None]
+            ok = True
+            for owner in owners_list:
+                res = self.controller.alter_default_privileges(
+                    role, schema, "tables", default_perms, owner=owner, emit_signal=False
+                )
+                ok = ok and res
+            return ok
 
         def on_success(success):
             if success:

--- a/tests/test_privileges_view.py
+++ b/tests/test_privileges_view.py
@@ -1,8 +1,12 @@
+import pathlib
+import sys
 import pytest
 pytest.importorskip("PyQt6.QtWidgets")
 from PyQt6.QtWidgets import QMessageBox
 
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from gerenciador_postgres.gui.users_view import UsersView
+from gerenciador_postgres.gui.privileges_view import PrivilegesView, PrivilegesState
 
 
 class DummyController:
@@ -54,3 +58,31 @@ def test_delete_group_without_removing_members(monkeypatch):
     view._on_delete_group()
     assert controller.deleted == "grp_test"
     assert controller.deleted_with_members is None
+
+
+def test_save_default_privileges_multiple_owners(monkeypatch):
+    class DummyPrivController:
+        def __init__(self):
+            self.calls = []
+
+        def alter_default_privileges(self, role, schema, obj, privs, owner=None, emit_signal=False):
+            self.calls.append((role, schema, owner, privs))
+            return True
+
+        def list_group_members(self, group):
+            return ["u1", "u2"]
+
+    controller = DummyPrivController()
+    view = PrivilegesView.__new__(PrivilegesView)
+    view.controller = controller
+    view.current_group = "grp"
+    st = PrivilegesState(default_privs={"SELECT"})
+    view._priv_cache = {("grp", "public"): st}
+    view._current_schema_checked = lambda: ("grp", "public")
+    view._update_save_all_state = lambda: None
+    view._execute_async = lambda func, on_success, on_error, label: on_success(func())
+    monkeypatch.setattr(
+        "gerenciador_postgres.gui.privileges_view.QMessageBox.information", lambda *a, **k: None
+    )
+    view._save_default_privileges(["u1", "u2"])
+    assert [c[2] for c in controller.calls] == ["u1", "u2"]


### PR DESCRIPTION
## Summary
- add 'Aplicar para...' button in PrivilegesView to apply defaults to selected users
- allow saving default privileges for multiple owners
- test that multiple owners are processed when saving defaults

## Testing
- `pytest tests/test_privileges_view.py tests/test_save_all_button.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7b963a3c4832e80d9f5fc06f84658