### PR TITLE
Apply default privileges when adding group members

### DIFF
--- a/gerenciador_postgres/controllers/groups_controller.py
+++ b/gerenciador_postgres/controllers/groups_controller.py
@@ -81,10 +81,20 @@ class GroupsController(QObject):
     def list_user_groups(self, username: str):
         return self._user_ctrl.list_user_groups(username)
 
-    def add_user_to_group(self, username: str, group_name: str) -> bool:
+    def add_user_to_group(
+        self,
+        username: str,
+        group_name: str,
+        auto_apply_defaults: bool = True,
+    ) -> bool:
         success = self.role_manager.add_user_to_group(username, group_name)
         if success:
             self.members_changed.emit(group_name)
+            if auto_apply_defaults:
+                try:
+                    self.apply_defaults_to_user(username)
+                except Exception:
+                    pass
         return success
 
     def remove_user_from_group(self, username: str, group_name: str) -> bool:
@@ -99,6 +109,44 @@ class GroupsController(QObject):
             self.members_changed.emit(old_group)
             self.members_changed.emit(new_group)
         return success
+
+    def apply_defaults_to_user(self, username: str) -> bool:
+        """Reaplica os ``ALTER DEFAULT PRIVILEGES`` existentes ao usuário."""
+        try:
+            data = self.role_manager.dao.get_default_privileges(objtype="r")
+        except Exception:
+            return False
+
+        user_groups = set()
+        try:
+            user_groups = set(self.list_user_groups(username))
+        except Exception:
+            pass
+
+        meta = data.pop("_meta", {})
+        owners = meta.get("owner_roles", {})
+        applied = False
+        for schema, grants in data.items():
+            owner = owners.get(schema)
+            privs: set = set()
+            for grp in user_groups:
+                privs |= grants.get(grp, set())
+            if privs:
+                try:
+                    self.alter_default_privileges(
+                        username,
+                        schema,
+                        "tables",
+                        privs,
+                        owner=owner,
+                        emit_signal=False,
+                    )
+                    applied = True
+                except Exception:
+                    continue
+        if applied:
+            self.data_changed.emit()
+        return applied
 
     # ---------------------------------------------------------------
     # Operações de privilégios

--- a/gerenciador_postgres/gui/users_view.py
+++ b/gerenciador_postgres/gui/users_view.py
@@ -458,10 +458,12 @@ class UsersView(QWidget):
         self.btnAddGrupo = QPushButton("<< Adicionar")
         self.btnRemGrupo = QPushButton("Remover >>")
         self.btnTransferGrupo = QPushButton("Transferir")
+        self.btnApplyDefaults = QPushButton("Reaplicar defaults")
         col_btns.addStretch()
         col_btns.addWidget(self.btnAddGrupo)
         col_btns.addWidget(self.btnRemGrupo)
         col_btns.addWidget(self.btnTransferGrupo)
+        col_btns.addWidget(self.btnApplyDefaults)
         col_btns.addStretch()
         lists_layout.addLayout(col_btns)
         # Grupos disponíveis
@@ -482,6 +484,7 @@ class UsersView(QWidget):
         self.btnAddGrupo.clicked.connect(self._add_group_to_user)
         self.btnRemGrupo.clicked.connect(self._remove_group_from_user)
         self.btnTransferGrupo.clicked.connect(self._transfer_group_user)
+        self.btnApplyDefaults.clicked.connect(self._on_apply_defaults)
         self.btnNewGroup.clicked.connect(self._on_new_group)
         self.btnDeleteGroup.clicked.connect(self._on_delete_group)
         self.btnNovo.clicked.connect(self.add_user)
@@ -584,6 +587,16 @@ class UsersView(QWidget):
             self._refresh_group_lists()
         else:
             QMessageBox.critical(self, "Erro", "Não foi possível transferir.")
+
+    def _on_apply_defaults(self):
+        username = self._current_username()
+        if not username:
+            return
+        try:
+            self.controller.apply_defaults_to_user(username)
+            QMessageBox.information(self, "Sucesso", "Defaults reaplicados.")
+        except Exception as e:
+            QMessageBox.critical(self, "Erro", f"Falha ao aplicar defaults: {e}")
 
     def _on_new_group(self):
         from gerenciador_postgres.config_manager import load_config

--- a/tests/test_groups_controller_apply_defaults.py
+++ b/tests/test_groups_controller_apply_defaults.py
@@ -1,0 +1,39 @@
+import pytest
+pytest.importorskip("PyQt6.QtCore")
+
+from gerenciador_postgres.controllers.groups_controller import GroupsController
+
+
+class DummyDAO:
+    def get_default_privileges(self, objtype="r"):
+        return {
+            "_meta": {"owner_roles": {"public": "owner1"}},
+            "public": {"grp_a": {"SELECT"}},
+        }
+
+
+class DummyRoleManager:
+    def __init__(self):
+        self.dao = DummyDAO()
+
+    def add_user_to_group(self, username, group):
+        return True
+
+
+def test_apply_defaults_to_user(monkeypatch):
+    rm = DummyRoleManager()
+    ctrl = GroupsController(rm)
+
+    monkeypatch.setattr(ctrl, "list_user_groups", lambda u: ["grp_a"])
+
+    calls = []
+
+    def fake_alter(role, schema, obj_type, privileges, owner=None, emit_signal=True):
+        calls.append((role, schema, obj_type, privileges, owner))
+        return True
+
+    ctrl.alter_default_privileges = fake_alter  # type: ignore
+
+    assert ctrl.apply_defaults_to_user("bob")
+    assert calls == [("bob", "public", "tables", {"SELECT"}, "owner1")]
+

--- a/tests/test_groups_controller_members_signal.py
+++ b/tests/test_groups_controller_members_signal.py
@@ -35,6 +35,6 @@ def test_members_changed_signal_emitted():
     received = []
     ctrl.members_changed.connect(received.append)
 
-    assert ctrl.add_user_to_group("alice", "grp_a")
+    assert ctrl.add_user_to_group("alice", "grp_a", auto_apply_defaults=False)
     assert received == ["grp_a"]
 


### PR DESCRIPTION
## Summary
- add optional `auto_apply_defaults` flag to group member addition
- implement `apply_defaults_to_user` and expose UI button to reapply defaults
- cover default privilege propagation with new tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7b96c0ae0832e940d055d832a8e8d