### PR TITLE
Handle default privileges for multiple owners

### DIFF
--- a/gerenciador_postgres/controllers/groups_controller.py
+++ b/gerenciador_postgres/controllers/groups_controller.py
@@ -132,13 +132,17 @@ class GroupsController(QObject):
             self._is_refreshing = False
 
         meta = data.pop("_meta", {})
-        owners = meta.get("owner_roles", {})
-        result = {}
+        owners = meta.get("owner_roles", {})  # schema -> {owner -> set(privs)}
+        result: dict[str, dict[str, set[str]]] = {}
         for schema, grants in data.items():
-            result[schema] = {
-                "owner": owners.get(schema),
-                "privileges": grants.get(group_name, set()),
-            }
+            group_privs = grants.get(group_name, set())
+            owner_map: dict[str, set[str]] = {}
+            for owner, privs in owners.get(schema, {}).items():
+                intersect = group_privs & privs
+                if intersect:
+                    owner_map[owner] = intersect
+            if owner_map:
+                result[schema] = owner_map
         return result
 
     def list_privilege_templates(self):

--- a/gerenciador_postgres/gui/privileges_view.py
+++ b/gerenciador_postgres/gui/privileges_view.py
@@ -51,8 +51,8 @@ class _TaskRunner(QThread):
 class PrivilegesState:
     schema_privs: set[str] = field(default_factory=set)
     table_privs: dict[str, set[str]] = field(default_factory=dict)
-    default_privs: set[str] = field(default_factory=set)
-    owner_role: str | None = None
+    # Default privileges are now tracked per owner role
+    default_privs: dict[str, set[str]] = field(default_factory=dict)
     dirty_schema: bool = False
     dirty_table: bool = False
     dirty_default: bool = False
@@ -494,14 +494,25 @@ class PrivilegesView(QWidget):
 
     def _update_default_priv(self, role: str, schema: str, priv: str, checked: bool):
         state = self._get_state(role, schema)
-        before = set(state.default_privs)
-        if checked:
-            state.default_privs.add(priv)
-        else:
-            state.default_privs.discard(priv)
-        if before != state.default_privs:
+        # Copy current privileges for change detection
+        before = {o: set(p) for o, p in state.default_privs.items()}
+        if not state.default_privs:
+            return
+        for privs in state.default_privs.values():
+            if checked:
+                privs.add(priv)
+            else:
+                privs.discard(priv)
+        after = {o: set(p) for o, p in state.default_privs.items()}
+        if before != after:
             state.dirty_default = True
-            logger.debug("[PrivilegesView] default_priv_changed role=%s schema=%s priv=%s now=%s", role, schema, priv, state.default_privs)
+            logger.debug(
+                "[PrivilegesView] default_priv_changed role=%s schema=%s priv=%s now=%s",
+                role,
+                schema,
+                priv,
+                state.default_privs,
+            )
             self._refresh_schema_dirty_indicators()
             self._update_save_all_state()
 
@@ -702,9 +713,19 @@ class PrivilegesView(QWidget):
         ok1 = self.controller.grant_schema_privileges(
             role, schema_base, state.schema_privs, emit_signal=False
         )
-        ok2 = self.controller.alter_default_privileges(
-            role, schema_base, "tables", state.default_privs, emit_signal=False
-        )
+        ok2 = True
+        for owner, privs in state.default_privs.items():
+            ok2 = (
+                self.controller.alter_default_privileges(
+                    role,
+                    schema_base,
+                    "tables",
+                    privs,
+                    owner=owner,
+                    emit_signal=False,
+                )
+                and ok2
+            )
         ok3 = self.controller.apply_group_privileges(
             role, {schema_base: state.table_privs}, defaults_applied=True, emit_signal=False
         )
@@ -847,21 +868,18 @@ class PrivilegesView(QWidget):
             schema_privs_all = self.controller.get_schema_level_privileges(role)
             schema_privs_db = schema_privs_all.get(schema_name, set())
             default_all = self.controller.get_default_table_privileges(role)
-            default_info = default_all.get(schema_name, {})
-            default_privs_db = default_info.get("privileges", set())
-            owner_role = default_info.get("owner")
+            default_privs_db = default_all.get(schema_name, {})  # owner -> set
             key = (role, schema_name)
             state = self._priv_cache.get(key)
             if not state:
                 state = PrivilegesState()
                 self._priv_cache[key] = state
-            state.owner_role = owner_role
             if not state.schema_privs:
                 state.schema_privs = set(schema_privs_db)
             if not state.default_privs:
-                state.default_privs = set(default_privs_db)
+                state.default_privs = {o: set(p) for o, p in default_privs_db.items()}
             schema_privs = state.schema_privs
-            default_privs = state.default_privs
+            default_privs_union = set().union(*state.default_privs.values()) if state.default_privs else set()
             logger.debug(
                 "[PrivilegesView] _update_schema_details role=%s schema=%s db_schema_privs=%s db_default_privs=%s cached_schema=%s cached_default=%s",
                 role,
@@ -869,7 +887,7 @@ class PrivilegesView(QWidget):
                 schema_privs_db,
                 default_privs_db,
                 schema_privs,
-                default_privs,
+                state.default_privs,
             )
         except Exception as e:  # pragma: no cover
             logging.exception("Erro ao ler privilégios de schema")
@@ -878,7 +896,8 @@ class PrivilegesView(QWidget):
                 "Erro",
                 f"Não foi possível ler os privilégios.\nMotivo: {e}",
             )
-            schema_privs, default_privs, owner_role = set(), set(), None
+            schema_privs, default_privs_union, default_privs_db = set(), set(), {}
+            state = PrivilegesState()
 
         usage_create_box = QGroupBox("Permissões no Schema")
         usage_create_layout = QHBoxLayout()
@@ -902,16 +921,16 @@ class PrivilegesView(QWidget):
         defaults_box = QGroupBox("Para Novas Tabelas (Privilégios Futuros)")
         defaults_layout = QHBoxLayout()
         self.cb_default_select = QCheckBox("SELECT")
-        self.cb_default_select.setChecked("SELECT" in default_privs)
+        self.cb_default_select.setChecked("SELECT" in default_privs_union)
         defaults_layout.addWidget(self.cb_default_select)
         self.cb_default_insert = QCheckBox("INSERT")
-        self.cb_default_insert.setChecked("INSERT" in default_privs)
+        self.cb_default_insert.setChecked("INSERT" in default_privs_union)
         defaults_layout.addWidget(self.cb_default_insert)
         self.cb_default_update = QCheckBox("UPDATE")
-        self.cb_default_update.setChecked("UPDATE" in default_privs)
+        self.cb_default_update.setChecked("UPDATE" in default_privs_union)
         defaults_layout.addWidget(self.cb_default_update)
         self.cb_default_delete = QCheckBox("DELETE")
-        self.cb_default_delete.setChecked("DELETE" in default_privs)
+        self.cb_default_delete.setChecked("DELETE" in default_privs_union)
         defaults_layout.addWidget(self.cb_default_delete)
         defaults_box.setLayout(defaults_layout)
         self.schema_details_layout.addWidget(defaults_box)
@@ -976,8 +995,9 @@ class PrivilegesView(QWidget):
             )
         )
 
-        if owner_role:
-            owner_label = QLabel(f"owner: {owner_role}")
+        if state.default_privs:
+            owners = ", ".join(sorted(state.default_privs))
+            owner_label = QLabel(f"owners: {owners}")
             self.schema_details_layout.addWidget(owner_label)
 
         self.schema_details_layout.addStretch()
@@ -1162,13 +1182,23 @@ class PrivilegesView(QWidget):
         if not role:
             return
         state = self._priv_cache.get((role, schema))
-        default_perms = set(state.default_privs) if state else set()
 
         def task():
-            owner = state.owner_role if state else None
-            return self.controller.alter_default_privileges(
-                role, schema, "tables", default_perms, owner=owner, emit_signal=False
-            )
+            ok = True
+            if state:
+                for owner, privs in state.default_privs.items():
+                    ok = (
+                        self.controller.alter_default_privileges(
+                            role,
+                            schema,
+                            "tables",
+                            privs,
+                            owner=owner,
+                            emit_signal=False,
+                        )
+                        and ok
+                    )
+            return ok
 
         def on_success(success):
             if success:

--- a/tests/test_default_privileges.py
+++ b/tests/test_default_privileges.py
@@ -67,5 +67,10 @@ def test_get_default_privileges_parsing():
         "SELECT",
         "UPDATE",
     }
-    assert res["_meta"]["owner_roles"]["geo2"] == "postgres"
+    assert res["_meta"]["owner_roles"]["geo2"]["postgres"] == {
+        "DELETE",
+        "INSERT",
+        "SELECT",
+        "UPDATE",
+    }
 

--- a/tests/test_privileges_view.py
+++ b/tests/test_privileges_view.py
@@ -1,8 +1,20 @@
+import os
 import pytest
 pytest.importorskip("PyQt6.QtWidgets")
-from PyQt6.QtWidgets import QMessageBox
+from PyQt6.QtWidgets import (
+    QApplication,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from gerenciador_postgres.gui.users_view import UsersView
+from gerenciador_postgres.gui.privileges_view import PrivilegesView
 
 
 class DummyController:
@@ -54,3 +66,34 @@ def test_delete_group_without_removing_members(monkeypatch):
     view._on_delete_group()
     assert controller.deleted == "grp_test"
     assert controller.deleted_with_members is None
+
+
+def test_update_schema_details_multiple_owners():
+    app = QApplication.instance() or QApplication([])
+
+    class Ctrl:
+        def get_schema_level_privileges(self, role):
+            return {"public": set()}
+
+        def get_default_table_privileges(self, role):
+            return {"public": {"owner1": {"SELECT"}, "owner2": {"INSERT"}}}
+
+    view = PrivilegesView.__new__(PrivilegesView)
+    QWidget.__init__(view)
+    view.controller = Ctrl()
+    view.current_group = "grp"
+    view.schema_list = QListWidget()
+    item = QListWidgetItem("public")
+    view.schema_list.addItem(item)
+    view.schema_details_layout = QVBoxLayout()
+    view.btnSchemaDelete = QPushButton()
+    view.btnSchemaOwner = QPushButton()
+    view._priv_cache = {}
+
+    view._update_schema_details(item, None)
+    state = view._priv_cache[("grp", "public")]
+    assert state.default_privs == {"owner1": {"SELECT"}, "owner2": {"INSERT"}}
+    assert view.cb_default_select.isChecked()
+    assert view.cb_default_insert.isChecked()
+    assert not view.cb_default_update.isChecked()
+    assert not view.cb_default_delete.isChecked()

--- a/tests/test_reconciler_default_privileges.py
+++ b/tests/test_reconciler_default_privileges.py
@@ -47,7 +47,7 @@ def test_diff_default_privileges_grant(monkeypatch):
 def test_diff_default_privileges_revoke(monkeypatch):
     states = {
         "r": {
-            "_meta": {"owner_roles": {"public": "owner"}},
+            "_meta": {"owner_roles": {"public": {"owner": {"SELECT"}}}},
             "public": {"grantee": {"SELECT"}},
         }
     }

--- a/tests/test_state_reader.py
+++ b/tests/test_state_reader.py
@@ -132,7 +132,12 @@ def test_get_default_privileges_parsing():
         "SELECT",
         "UPDATE",
     }
-    assert res["_meta"]["owner_roles"]["geo2"] == "postgres"
+    assert res["_meta"]["owner_roles"]["geo2"]["postgres"] == {
+        "DELETE",
+        "INSERT",
+        "SELECT",
+        "UPDATE",
+    }
 
 
 class DummyCursorRoles:


### PR DESCRIPTION
## Summary
- Track default privileges per owner in DB manager and groups controller
- Store default privileges per owner in PrivilegesView state and UI
- Add tests covering multiple default privilege owners

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7b9655294832e933c3c2f8c36db65