### PR TITLE
Remove unused legacy save privileges method

### DIFF
--- a/gerenciador_postgres/gui/privileges_view.py
+++ b/gerenciador_postgres/gui/privileges_view.py
@@ -1358,13 +1358,6 @@ class PrivilegesView(QWidget):
             QMessageBox.critical(self, "Erro", f"Falha ao salvar tudo: {e}")
         self._execute_async(task, on_success, on_error, "Salvando tudo...")
 
-    # Mantém método antigo para compatibilidade interna, chamando os três (se necessário)
-    def _save_privileges(self):  # legacy
-        self._save_db_privileges()
-        self._save_schema_privileges()
-        self._save_default_privileges()
-        self._save_table_privileges()
-
     def _refresh_members(self):
         self.lstMembers.clear()
         if not self.controller or not self.current_group:


### PR DESCRIPTION
## Summary
- Remove obsolete `_save_privileges` method from `privileges_view`

## Testing
- `pytest` *(fails: tests/test_user_group_management.py::UserGroupManagementTests::test_add_user_applies_default_privileges)*

------
https://chatgpt.com/codex/tasks/task_e_68a87f272e28832e8340aff050f6865f